### PR TITLE
Add vac.mvds package

### DIFF
--- a/mvds.md
+++ b/mvds.md
@@ -45,6 +45,8 @@ Payloads are implemented using [protocol buffers v3](https://developers.google.c
 ```protobuf
 syntax = "proto3";
 
+package vac.mvds;
+
 message Payload {
   repeated bytes acks = 5001;
   repeated bytes offers = 5002;


### PR DESCRIPTION
Add packages to create more clear namespaced protobufs. Similar to `vac.remotelog`, etc.

I don't *think* it impacts compatibility across clients, but would be worth confirming. Anyone knows for sure?