### PR TITLE
update/field-numbers

### DIFF
--- a/mvds.md
+++ b/mvds.md
@@ -48,16 +48,16 @@ syntax = "proto3";
 package vac.mvds;
 
 message Payload {
-  repeated bytes acks = 5001;
-  repeated bytes offers = 5002;
-  repeated bytes requests = 5003;
-  repeated Message messages = 5004;
+  repeated bytes acks = 1;
+  repeated bytes offers = 2;
+  repeated bytes requests = 3;
+  repeated Message messages = 4;
 }
 
 message Message {
-  bytes group_id = 6001;
-  int64 timestamp = 6002;
-  bytes body = 6003;
+  bytes group_id = 1;
+  int64 timestamp = 2;
+  bytes body = 3;
 }
 ```
 

--- a/mvds.md
+++ b/mvds.md
@@ -1,6 +1,6 @@
 # Minimum Viable Data Synchronization
 
-> Version: 0.5.2 (Draft)
+> Version: 0.6.0 (Draft)
 > 
 > Authors: Oskar Thorén <oskar@status.im>, Dean Eigenmann <dean@status.im>
 


### PR DESCRIPTION
The field numbers were originally changed to larger values for fear of collision. Reading into protocol buffers I do not think this is possible, also we do not need to care about this on this level as we assume MVDS payloads to be the lowest packet transported.

Additionally, Field numbers 1-15 only take one byte to encode, whereas 16-2047 take two. As this is a frequently occurring protobuf it would be good to have the fields be as small as possible. 

Ref: https://developers.google.com/protocol-buffers/docs/proto#assigning-field-numbers 