### PR TITLE
spec/waku-rate-limiting

### DIFF
--- a/waku.md
+++ b/waku.md
@@ -142,7 +142,7 @@ required-packet = 0 status /
 		  2 pow-requirement /
 		  3 bloom-filter
 		  
-optional-packet = 126 p2p-request / 127 p2p-message / 14 rate-limits
+optional-packet = 126 p2p-request / 127 p2p-message / 20 rate-limits
 
 packet = "[" required-packet [ optional-packet ] "]"
 ```
@@ -253,7 +253,7 @@ Each node MAY decide to whitelist, i.e. do not rate limit, selected IPs or peer 
 
 If a peer exceeds node's rate limits, the connection between them MAY be dropped.
 
-Each node SHOULD broadcast its rate limits to its peers using rate limits packet code (`0x14`). The rate limits MAY also be sent as an optional parameter in the handshake.
+Each node SHOULD broadcast its rate limits to its peers using the rate limits packet. The rate limits MAY also be sent as an optional parameter in the handshake.
 
 Each node SHOULD respect rate limits advertised by its peers. The number of packets SHOULD be throttled in order not to exceed peer's rate limits. If the limit gets exceeded, the connection MAY be dropped by the peer.
 

--- a/waku.md
+++ b/waku.md
@@ -194,11 +194,8 @@ message is received, the node MUST ignore these messages and SHOULD disconnect
 from that peer.
 Status messages received after the handshake is completed MUST also be ignored.
 
-<<<<<<< HEAD
-=======
 The fields `bloom-filter`, `light-node`, `confirmations-enabled` and `rate-limits` are OPTIONAL. However if an optional field is specified, all subsequent fields MUST be specified in order to be unambiguous.
 
->>>>>>> master
 **Messages**
 
 This packet is used for sending the standard Waku envelopes.


### PR DESCRIPTION
closes #40 

the ratelimting packet is assigned in PR #65, hence not redfined here.

uses info from https://github.com/status-im/specs/pull/60