### PR TITLE
Waku v0.4

### DIFF
--- a/specs/waku/waku.md
+++ b/specs/waku/waku.md
@@ -518,7 +518,7 @@ Known static nodes MAY also be used.
 
 ### Version 0.4
 
-Released [February 20, 2020](https://github.com/vacp2p/specs/commit/ce12c499e0ac484dee2b05a307c86a164ae3f178).
+Released [February 21, 2020](https://github.com/vacp2p/specs/commit/17bd066e317bbe33af07146b721d73f24de47e88).
 
 - Simplify implementation matrix with latest state
 - Introduces a new required packet code Status Code (`0x22`) for communicating option changes


### PR DESCRIPTION
- Simplify implementation matrix with latest state
- Introduces a new required packet code Status Code (`0x22`) for communicating option changes
- Deprecates the following packet codes: PoW Requirement (`0x02`), Bloom Filter (`0x03`), Rate limits (`0x20`), Topic interest (`0x21`) - all superseded by the new Status Code (`0x22`)
- Increased `topic-interest` capacity from 1000 to 10000

Tagged release