### PR TITLE
Removed light client option from Waku / Whisper diff

### DIFF
--- a/specs/waku/waku-0.md
+++ b/specs/waku/waku-0.md
@@ -578,7 +578,6 @@ Initial version. Released [November 21, 2019](https://github.com/vacp2p/specs/bl
 Summary of main differences between this spec and Whisper v6, as described in [EIP-627](https://eips.ethereum.org/EIPS/eip-627):
 
 - RLPx subprotocol is changed from `shh/6` to `waku/0`.
-- Light node capability is added.
 - Optional rate limiting is added.
 - Status packet has following additional parameters: light-node,
 confirmations-enabled and rate-limits

--- a/specs/waku/waku-1.md
+++ b/specs/waku/waku-1.md
@@ -590,7 +590,6 @@ Initial version. Released [November 21, 2019](https://github.com/vacp2p/specs/bl
 Summary of main differences between this spec and Whisper v6, as described in [EIP-627](https://eips.ethereum.org/EIPS/eip-627):
 
 - RLPx subprotocol is changed from `shh/6` to `waku/1`.
-- Light node capability is added.
 - Optional rate limiting is added.
 - Status packet has following additional parameters: light-node,
 confirmations-enabled and rate-limits


### PR DESCRIPTION
As far as I can see Whisper had the same light client functionality as Waku https://github.com/ethereum/go-ethereum/blob/510b6f90db406b697610fe0ff2eee66d173673b2/whisper/whisperv6/whisper.go#L291 . I am happy to be corrected though.

The Whisper specs don't seem to mention a light client, but the Whisper code base has functionality that matches the Waku specs for light clients.

**Waku Specs**
>Light nodes MUST NOT forward any incoming messages, they MUST only send their own messages.

**Whisper code comment**
>//LightClientMode indicates is this node is light client (does not forward any messages)

Is there other functionality or divergence that the Waku light client / node has compared to Whisper?