### PR TITLE
Be consistent in usage of terms packet, message and envelope

### DIFF
--- a/specs/waku/envelope-data-format.md
+++ b/specs/waku/envelope-data-format.md
@@ -18,11 +18,11 @@ redirect_from:
 
 ## Abstract
 
-In this specification, we describe the [data field used in Waku](waku.md#abnf-specification) for the encryption, decryption and signing of messages.
+This specification describes the encryption, decryption and signing of the content in the [data field used in Waku](waku.md#abnf-specification).
 
 ## Specification
 
-The `data` field is used within the `waku envelope`, the field MUST contain the encrypted message of the envelope.
+The `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the envelope.
 
 The fields that are concatenated and encrypted as part of the `data` field are:
  - flags
@@ -62,11 +62,11 @@ envelope        = flags auxiliary-field payload padding [signature] [salt]
 
 ### Signature
 
-Those unable to decrypt the message data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialised as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` MUST be big-endian encoded, fixed-width 256-bit unsigned. `V` MUST be an 8-bit big-endian encoded, non-normalised and should be either 27 or 28.
+Those unable to decrypt the envelope data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialised as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` MUST be big-endian encoded, fixed-width 256-bit unsigned. `V` MUST be an 8-bit big-endian encoded, non-normalised and should be either 27 or 28.
 
 ### Padding
 
-The padding field is used to align message size, since message size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+The padding field is used to align data size, since data size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
 
 ## Copyright
 

--- a/specs/waku/mailserver.md
+++ b/specs/waku/mailserver.md
@@ -11,24 +11,24 @@ redirect_from:
 
 1. [Abstract](#abstract)
 2. [Specification](#specification)
-    1. [Requesting messages](#requesting-messages)
-    2. [Receiving historic messages](#receiving-historic-messages)
+    1. [Requesting Historic Envelopes](#requesting-historic-envelopes)
+    2. [Receiving Historic Envelopes](#receiving-historic-envelopes)
     3. [Security considerations](#security-considerations)
 3. [Copyright](#copyright)
 
 ## Abstract
 
-In this specification, we describe Mailservers. These are nodes responsible for archiving messages and delivering them too peers on-demand.
+In this specification, we describe Mailservers. These are nodes responsible for archiving envelopes and delivering them to peers on-demand.
 
 ## Specification
 
-A node which wants to provide mailserver functionality MUST store envelopes from incoming message packets (Waku packet-code 0x01). The envelopes can be stored in any format, however they MUST be serialized and deserialized to the Waku envelope format.
+A node which wants to provide mailserver functionality MUST store envelopes from incoming Messages packets (Waku packet-code `0x01`). The envelopes can be stored in any format, however they MUST be serialized and deserialized to the Waku envelope format.
 
 A mailserver SHOULD store envelopes for all topics to be generally useful for any peer, however for specific use cases it MAY store envelopes for a subset of topics.
 
-### Requesting messages
+### Requesting Historic Envelopes
 
-In order to request historic messages, a node MUST send a packet P2P Request (`0x7e`) to a peer providing mailserver functionality. This packet requires one argument which MUST be a Waku envelope.
+In order to request historic envelopes, a node MUST send a packet P2P Request (`0x7e`) to a peer providing mailserver functionality. This packet requires one argument which MUST be a Waku envelope.
 
 In the Waku envelope's payload section, there MUST be RLP-encoded information about the details of the request:
 
@@ -65,17 +65,17 @@ The `Cursor` field SHOULD be filled in if a number of envelopes between `Lower` 
 
 The envelope MUST be encrypted with a symmetric key agreed between the requester and Mailserver.
 
-If `Topics` is used the `Cursor` field MUST be specified for the argument order to be unambiguous. However, it MAY be set to `null`. `Topics` is used to specify which topics a node is interested in. If `Topics` is not empty, a mailserver MUST only send messages that belong to a topic from `Topics` list and `Bloom` value MUST be ignored.
+If `Topics` is used the `Cursor` field MUST be specified for the argument order to be unambiguous. However, it MAY be set to `null`. `Topics` is used to specify which topics a node is interested in. If `Topics` is not empty, a mailserver MUST only send envelopes that belong to a topic from `Topics` list and `Bloom` value MUST be ignored.
 
-### Receiving historic messages
+### Receiving Historic Envelopes
 
-Historic messages MUST be sent to a peer as a packet with a P2P Message code (`0x7f`) followed by an array of Waku envelopes.
+Historic envelopes MUST be sent to a peer as a packet with a P2P Message code (`0x7f`) followed by an array of Waku envelopes.
 
-In order to receive historic messages from a mailserver, a node MUST trust the selected mailserver, that is allow to receive expired packets with the P2P Message code. By default, such packets are discarded.
+In order to receive historic envelopes from a mailserver, a node MUST trust the selected mailserver, that is allow to receive expired packets with the P2P Message code. By default, such packets are discarded.
 
 Received envelopes MUST be passed through the Whisper envelope pipelines so that they are picked up by registered filters and passed to subscribers.
 
-For a requester, to know that all messages have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by a list with:
+For a requester, to know that all envelopes have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by a list with:
 
 ```abnf
 ; array with a Keccak-256 hash of the envelope containing the original request.
@@ -90,7 +90,7 @@ cursor = *OCTET
 payload = "[" request-id last-envelope-hash [ cursor ] "]"
 ```
 
-If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of the messages.
+If `Cursor` is not empty, it means that not all envelopes were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of the envelopes.
 
 ### Security considerations
 
@@ -98,7 +98,7 @@ There are several security considerations to take into account when running or i
 
 **Mailserver High Availability requirement:**
 
-A mailserver has to be online to receive messages for other nodes, this puts a high availability requirement on it.
+A mailserver has to be online to receive envelopes for other nodes, this puts a high availability requirement on it.
 
 **Mailserver client privacy:**
 

--- a/specs/waku/waku-1.md
+++ b/specs/waku/waku-1.md
@@ -52,19 +52,19 @@ redirect_from:
 
 ## Abstract
 
-This specification describes the format of Waku messages within the ÐΞVp2p Wire Protocol. This spec substitutes [EIP-627](https://eips.ethereum.org/EIPS/eip-627). Waku is a fork of the original Whisper protocol that enables better usability for resource restricted devices, such as mostly-offline bandwidth-constrained smartphones. It does this through (a) light node support, (b) historic messages (with a mailserver) (c) expressing topic interest for better bandwidth usage and (d) basic rate limiting.
+This specification describes the format of Waku packets within the ÐΞVp2p Wire Protocol. This spec substitutes [EIP-627](https://eips.ethereum.org/EIPS/eip-627). Waku is a fork of the original Whisper protocol that enables better usability for resource restricted devices, such as mostly-offline bandwidth-constrained smartphones. It does this through (a) light node support, (b) historic envelopes (with a mailserver) (c) expressing topic interest for better bandwidth usage and (d) basic rate limiting.
 
 ## Motivation
 
-Waku was created to incrementally improve in areas that Whisper is lacking in, with special attention to resource restricted devices. We specify the standard for Waku messages in order to ensure forward compatibility of different Waku clients, backwards compatibility with Whisper clients, as well as to allow multiple implementations of Waku and its capabilities. We also modify the language to be more unambiguous, concise and consistent.
+Waku was created to incrementally improve in areas that Whisper is lacking in, with special attention to resource restricted devices. We specify the standard for Waku packets in order to ensure forward compatibility of different Waku clients, backwards compatibility with Whisper clients, as well as to allow multiple implementations of Waku and its capabilities. We also modify the language to be more unambiguous, concise and consistent.
 
 ## Definitions
 
-| Term            | Definition                                            |
-| --------------- | ----------------------------------------------------- |
-| **Light node**  | A Waku node that does not forward any messages.       |
-| **Envelope**    | Messages sent and received by Waku nodes.             |
-| **Node**        | Some process that is able to communicate for Waku.    |
+| Term            | Definition                                                                  |
+| --------------- | ----------------------------------------------------------------------------|
+| **Light node**  | A Waku node that does not forward any envelopes through the Messages packet.|
+| **Envelope**    | Messages sent and received by Waku nodes.                                   |
+| **Node**        | Some process that is able to communicate for Waku.                          |
 
 ## Underlying Transports and Prerequisites
 
@@ -76,13 +76,13 @@ This protocol needs to advertise the `waku/1` [capability](https://ethereum.gitb
 
 ### Gossip based routing
 
-In Whisper, messages are gossiped between peers. Whisper is a form of rumor-mongering protocol that works by flooding to its connected peers based on some factors. Messages are eligible for retransmission until their TTL expires. A node SHOULD relay messages to all connected nodes if an envelope matches their PoW and bloom filter settings. If a node works in light mode, it MAY choose not to forward envelopes. A node MUST NOT send expired envelopes, unless the envelopes are sent as a [mailserver](./mailserver.md) response. A node SHOULD NOT send a message to a peer that it has already sent before.
+In Whisper, envelopes are gossiped between peers. Whisper is a form of rumor-mongering protocol that works by flooding to its connected peers based on some factors. Envelopes are eligible for retransmission until their TTL expires. A node SHOULD relay envelopes to all connected nodes if an envelope matches their PoW and bloom filter settings. If a node works in light mode, it MAY choose not to forward envelopes. A node MUST NOT send expired envelopes, unless the envelopes are sent as a [mailserver](./mailserver.md) response. A node SHOULD NOT send an envelope to a peer that it has already sent before.
 
 ## Wire Specification
 
 ### Use of RLPx transport protocol
 
-All Waku messages are sent as devp2p RLPx transport protocol, version 5[^1] packets. These packets MUST be RLP-encoded arrays of data containing two objects: packet code followed by another object (whose type depends on the packet code).  See [informal RLP spec](https://github.com/ethereum/wiki/wiki/RLP) and the [Ethereum Yellow Paper, appendix B](https://ethereum.github.io/yellowpaper/paper.pdf) for more details on RLP.
+All Waku packets are sent as devp2p RLPx transport protocol, version 5[^1] packets. These packets MUST be RLP-encoded arrays of data containing two objects: packet code followed by another object (whose type depends on the packet code).  See [informal RLP spec](https://github.com/ethereum/wiki/wiki/RLP) and the [Ethereum Yellow Paper, appendix B](https://ethereum.github.io/yellowpaper/paper.pdf) for more details on RLP.
 
 Waku is a RLPx subprotocol called `waku` with version `0`. The version number corresponds to the major version in the header spec. Minor versions should not break compatiblity of `waku`, this would result in a new major. (Some expections to this apply in the Draft stage of where client implementation is rapidly change).
 
@@ -151,7 +151,7 @@ ttl = 4OCTET
 topic = 4OCTET
 
 ; byte array of arbitrary size
-; (contains encrypted message)
+; (contains encrypted payload)
 data = OCTET
 
 ; 8 bytes of arbitrary data
@@ -185,9 +185,9 @@ All primitive types are RLP encoded. Note that, per RLP specification, integers 
 
 ### Packet Codes
 
-The message codes reserved for Waku protocol: 0 - 127.
+The packet codes reserved for Waku protocol: 0 - 127.
 
-Messages with unknown codes MUST be ignored without generating any error, for forward compatibility of future versions.
+Packets with unknown codes MUST be ignored without generating any error, for forward compatibility of future versions.
 
 The Waku sub-protocol MUST support the following packet codes:
 
@@ -211,21 +211,21 @@ The following message codes are optional, but they are reserved for specific pur
 
 #### Status
 
-The Status message serves as a Waku handshake and peers MUST exchange this
-message upon connection. It MUST be sent after the RLPx handshake and prior to
-any other Waku messages.
+The Status packet serves as a Waku handshake and peers MUST exchange this
+packet upon connection. It MUST be sent after the RLPx handshake and prior to
+any other Waku packets.
 
-A Waku node MUST await the Status message from a peer before engaging in other Waku protocol activity with that peer.
-When a node does not receive the Status message from a peer, before a configurable timeout, it SHOULD disconnect from that peer.
+A Waku node MUST await the Status packet from a peer before engaging in other Waku protocol activity with that peer.
+When a node does not receive the Status packet from a peer, before a configurable timeout, it SHOULD disconnect from that peer.
 
-Upon retrieval of the Status message, the node SHOULD validate the message
-received and validated the Status message. Note that its peer might not be in
+Upon retrieval of the Status packet, the node SHOULD validate the packet
+received and validated the Status packet. Note that its peer might not be in
 the same state.
 
-When a node is receiving other Waku messages from a peer before a Status
-message is received, the node MUST ignore these messages and SHOULD disconnect from that peer. Status messages received after the handshake is completed MUST also be ignored.
+When a node is receiving other Waku packets from a peer before a Status
+packet is received, the node MUST ignore these packets and SHOULD disconnect from that peer. Status packets received after the handshake is completed MUST also be ignored.
 
-The status message MUST contain an association list containing various options. All options within this association list are OPTIONAL, ordering of the key-value pairs is not guaranteed and therefore MUST NOT be relied on. Unknown keys in the association list SHOULD be ignored.
+The Status packet MUST contain an association list containing various options. All options within this association list are OPTIONAL, ordering of the key-value pairs is not guaranteed and therefore MUST NOT be relied on. Unknown keys in the association list SHOULD be ignored.
 
 #### Messages
 
@@ -233,17 +233,17 @@ This packet is used for sending the standard Waku envelopes.
 
 #### Status Update
 
-The Status Update message is used to communicate an update of the settings of the node.
-The format is the same as the Status message, all fields are optional.
-If none of the options are specified the message MUST be ignored and considered a noop.
+The Status Update packet is used to communicate an update of the settings of the node.
+The format is the same as the Status packet, all fields are optional.
+If none of the options are specified the packet MUST be ignored and considered a noop.
 Fields that are omitted are considered unchanged, fields that haven't changed SHOULD not 
 be transmitted.
 
 ##### PoW Requirement Field
 
-When PoW is updated, peers MUST NOT deliver the sender envelopes with PoW lower than specified in this message.
+When PoW Requirement is updated, peers MUST NOT deliver envelopes with PoW lower than the PoW Requirement specified.
 
-PoW is defined as average number of iterations, required to find the current BestBit (the number of leading zero bits in the hash), divided by message size and TTL:
+PoW is defined as average number of iterations, required to find the current BestBit (the number of leading zero bits in the hash), divided by envelope size and TTL:
 
 	PoW = (2**BestBit) / (size * TTL)
 
@@ -280,7 +280,7 @@ A bloom filter with all bits set to 0 signals that the node is not currently int
 
 ##### Topic Interest Field
 
-Topic interest is used to share a node's interest in messages with specific topics. It does this in a more bandwidth considerate way, at the expense of some metadata protection. Peers MUST only send envelopes with specified topics.
+Topic interest is used to share a node's interest in envelopes with specific topics. It does this in a more bandwidth considerate way, at the expense of some metadata protection. Peers MUST only send envelopes with specified topics.
 
 
 It is currently bounded to a maximum of 10000 topics. If you are interested in more topics than that, this is currently underspecified and likely requires updating it. The constant is subject to change.
@@ -305,13 +305,13 @@ Each node SHOULD respect rate limits advertised by its peers. The number of pack
 
 ##### Message Confirmations Field
 
-Message confirmations tell a node that a message originating from it has been received by its peers, allowing a node to know whether a message has or has not been received.
+Message confirmations tell a node that a envelope originating from it has been received by its peers, allowing a node to know whether an envelope has or has not been received.
 
-A node MAY send a message confirmation for any batch of messages received with a Messages packet (`0x01`).
+A node MAY send a message confirmation for any batch of envelopes received with a Messages packet (`0x01`).
 
 A message confirmation is sent using Batch Ack packet (`0x0B`) or Message Response packet (`0x0C`). The message confirmation is specified in the ABNF specification below.
 
-The current `version` of the message response is `1`.
+The current `version` of the Message Response is `1`.
 
 Using [Augmented Backus-Naur form (ABNF)](https://tools.ietf.org/html/rfc5234) we have the following format:
 
@@ -341,20 +341,20 @@ confirmation = "[" version response "]"
 The supported codes:
 `1`: means time sync error which happens when an envelope is too old or created in the future (the root cause is no time sync between nodes).
 
-The drawback of sending message confirmations is that it increases the noise in the network because for each sent message, a corresponding confirmation is broadcasted by one or more peers.
+The drawback of sending message confirmations is that it increases the noise in the network because for each sent envelope, a corresponding confirmation is broadcasted by one or more peers.
 
 
 #### P2P Request
 
-This packet is used for sending Dapp-level peer-to-peer requests, e.g. Waku Mail Client requesting old messages from the [Waku Mail Server](./mailserver.md).
+This packet is used for sending Dapp-level peer-to-peer requests, e.g. Waku Mail Client requesting historic (expired) envelopes from the [Waku Mail Server](./mailserver.md).
 
 #### P2P Message
 
-This packet is used for sending the peer-to-peer messages, which are not supposed to be forwarded any further. E.g. it might be used by the Waku Mail Server for delivery of old (expired) messages, which is otherwise not allowed.
+This packet is used for sending the peer-to-peer envelopes, which are not supposed to be forwarded any further. E.g. it might be used by the Waku Mail Server for delivery of historic (expired) envelopes, which is otherwise not allowed.
 
 #### P2P Request Complete
 
-This packet is used to indicate that all messages, requested earlier with a P2P Request packet (`0x7E`), have been sent via one or more P2P Message packets (`0x7F`).
+This packet is used to indicate that all envelopes, requested earlier with a P2P Request packet (`0x7E`), have been sent via one or more P2P Message packets (`0x7F`).
 
 The content of the packet is explained in the [Waku Mail Server](./mailserver.md) specification.
 
@@ -370,7 +370,7 @@ Packet codes `0x00` and `0x01` are already used in all Waku / Whisper versions. 
 
 Packet code `0x22` is used to dynamically change the settings of a node.
 
-Packet codes `0x7E` and `0x7F` may be used to implement Waku Mail Server and Client. Without P2P messages it would be impossible to deliver the old messages, since they will be recognized as expired, and the peer will be disconnected for violating the Whisper protocol. They might be useful for other purposes when it is not possible to spend time on PoW, e.g. if a stock exchange will want to provide live feed about the latest trades.
+Packet codes `0x7E` and `0x7F` may be used to implement Waku Mail Server and Client. Without the P2P Message packet it would be impossible to deliver the historic envelopes, since they will be recognized as expired, and the peer will be disconnected for violating the Waku protocol. They might be useful for other purposes when it is not possible to spend time on PoW, e.g. if a stock exchange will want to provide live feed about the latest trades.
 
 ## Additional capabilities
 
@@ -382,9 +382,9 @@ Additionally there is the capability of a mailserver which is documented in its 
 
 The rationale for light nodes is to allow for interaction with waku on resource restricted devices as bandwidth can often be an issue.
 
-Light nodes MUST NOT forward any incoming messages, they MUST only send their own messages. When light nodes happen to connect to each other, they SHOULD disconnect. As this would result in messages being dropped between the two.
+Light nodes MUST NOT forward any incoming envelopes, they MUST only send their own envelopes. When light nodes happen to connect to each other, they SHOULD disconnect. As this would result in envelopes being dropped between the two.
 
-Light nodes are identified by the `light_node` value in the status message.
+Light nodes are identified by the `light_node` value in the Status packet.
 
 ### Accounting for resources (experimental)
 
@@ -424,7 +424,7 @@ Examples:
 - We enable bridging between `shh/6` and `waku/1` until such a time as when we are ready to gracefully drop support for `shh/6` (1, 2, 3).
 - When we add parameter fields, we (currently) do so by accreting them in a list, so old clients can ignore new fields (dynamic list) and new clients can use new capabilities (1, 3).
 - To better support (2) and (3) in the future, we will likely release a new version that gives better support for open, growable maps (association lists or native map type) (3)
-- When we we want to provide a new set of messages that have different requirements, we do so under a new protocol version and employ protocol versioning. This is a form of accretion at a level above - it ensures a client can support both protocols at once and drop support for legacy versions gracefully. (1,2,3)
+- When we we want to provide a new set of packets that have different requirements, we do so under a new protocol version and employ protocol versioning. This is a form of accretion at a level above - it ensures a client can support both protocols at once and drop support for legacy versions gracefully. (1,2,3)
 
 ### Backwards Compatibility
 
@@ -440,17 +440,17 @@ Waku is a different subprotocol from Whisper so it isn't directly compatible. Ho
 - WakuWhisper bridge C, both Waku and Whisper capability
 
 **Flow:**
-1. A posts message; B posts message.
-2. C picks up message from A and B and relays them both to Waku and Whisper.
-3. A receives message on Waku; B on Whisper.
+1. A posts envelope; B posts envelope.
+2. C picks up envelope from A and B and relays them both to Waku and Whisper.
+3. A receives envelope on Waku; B on Whisper.
 
-**Note**: This flow means if another bridge C1 is active, we might get duplicate relaying for a message between C1 and C2. I.e. Whisper(<>Waku<>Whisper)<>Waku, A-C1-C2-B. Theoretically this bridging chain can get as long as TTL permits.
+**Note**: This flow means if another bridge C1 is active, we might get duplicate relaying for a envelope between C1 and C2. I.e. Whisper(<>Waku<>Whisper)<>Waku, A-C1-C2-B. Theoretically this bridging chain can get as long as TTL permits.
 
 ### Forward Compatibility
 
 It is desirable to have a strategy for maintaining forward compatibility between `waku/1` and future version of waku. Here we outline some concerns and strategy for this.
 
-- **Connecting to nodes with multiple versions:** The way this SHOULD be accomplished is by negotiating the versions of subprotocols, within the `hello` message nodes transmit their capabilities along with a version. The highest common version should then be used.
+- **Connecting to nodes with multiple versions:** The way this SHOULD be accomplished is by negotiating the versions of subprotocols, within the `hello` packet nodes transmit their capabilities along with a version. The highest common version should then be used.
 - **Adding new packet codes:** New packet codes can be added easily due to the available packet codes. Unknown packet codes SHOULD be ignored. Upgrades that add new packet codes SHOULD implement some fallback mechanism if no response was received for nodes that do not yet understand this packet.
 - **Adding new options in `status-options`:** New options can be added to the `status-options` association list in the `status` and `status-update` packet as options are OPTIONAL and unknown option keys SHOULD be ignored. A node SHOULD NOT disconnect from a peer when receiving `status-options` with unknown option keys.
 
@@ -466,7 +466,7 @@ In version 0 of Waku, bandwidth usage is likely to be an issue. For more investi
 
 #### Gossip-based routing:
 
-Use of gossip-based routing doesn't necessarily scale. It means each node can see a message multiple times, and having too many light nodes can cause propagation probability that is too low. See [Whisper vs PSS](https://our.status.im/whisper-pss-comparison/) for more and a possible Kademlia based alternative.
+Use of gossip-based routing doesn't necessarily scale. It means each node can see an envelope multiple times, and having too many light nodes can cause propagation probability that is too low. See [Whisper vs PSS](https://our.status.im/whisper-pss-comparison/) for more and a possible Kademlia based alternative.
 
 #### Lack of incentives:
 
@@ -476,11 +476,11 @@ Waku currently lacks incentives to run nodes, which means node operators are mor
 
 #### Light node privacy:
 
-The main privacy concern with light nodes is that directly connected peers will know that a message originates from them (as it are the only ones it sends). This means nodes can make assumptions about what messages (topics) their peers are interested in.
+The main privacy concern with light nodes is that directly connected peers will know that an envelope originates from them (as it are the only ones it sends). This means nodes can make assumptions about what envelopes (topics) their peers are interested in.
 
 #### Bloom filter privacy:
 
-By having a bloom filter where only the topics you are interested in are set, you reveal which messages you are interested in. This is a fundamental tradeoff between bandwidth usage and privacy, though the tradeoff space is likely suboptimal in terms of the [Anonymity](https://eprint.iacr.org/2017/954.pdf) [trilemma](https://petsymposium.org/2019/files/hotpets/slides/coordination-helps-anonymity-slides.pdf).
+By having a bloom filter where only the topics you are interested in are set, you reveal which envelopes you are interested in. This is a fundamental tradeoff between bandwidth usage and privacy, though the tradeoff space is likely suboptimal in terms of the [Anonymity](https://eprint.iacr.org/2017/954.pdf) [trilemma](https://petsymposium.org/2019/files/hotpets/slides/coordination-helps-anonymity-slides.pdf).
 
 #### Privacy guarantees not rigorous:
 
@@ -535,6 +535,7 @@ Known static nodes MAY also be used.
 
 - Add section on P2P Request Complete packet and update packet code table.
 - Correct the header hierarchy for the status-options fields.
+- Consistent use of the words packet, message and envelope.
 
 ### Version 1.0
 
@@ -573,7 +574,7 @@ Released [February 13, 2020](https://github.com/vacp2p/specs/commit/73138d6ba954
 - Recommend DNS based node discovery over other Discovery methods.
 - Mark spec as Draft mode in terms of its lifecycle.
 - Simplify Changelog and misc formatting.
-- Handshake/Status message not compatible with shh/6 nodes; specifying options as association list.
+- Handshake/Status packet not compatible with shh/6 nodes; specifying options as association list.
 - Include topic-interest in Status handshake.
 - Upgradability policy.
 - `topic-interest` packet code.


### PR DESCRIPTION
After it was brought to our attention [here](https://discuss.status.im/t/wherefore-art-thou-mailserver-treatise-on-waku-terminology/1664) that the inconsistent usage of some terms made it difficult to understand the Waku spec, I decided to rework this.

Packet & Envelope are clearly defined. Message not really (more general term), but it is used still in the names of the packet types itself (I'm not going to change that). 
I also removed the usage of the term message for the encrypted payload, which means we could still decide to usage the message term in the way we use envelopes now in the text. After all in the definition of Waku envelope we call it a message.
But at the moment I decided to just replace all those message terms with envelope.

