### PR TITLE
Add missing packet types to abnf + abnf minor fixes

### DIFF
--- a/specs/waku/envelope-data-format.md
+++ b/specs/waku/envelope-data-format.md
@@ -57,7 +57,7 @@ signature       = 65OCTET
 ; 2 bytes, if present (in case of symmetric encryption).
 salt            = 2OCTET
 
-envelope        = flags auxiliary-field payload padding [signature] [salt]
+data        = flags auxiliary-field payload padding [signature] [salt]
 ```
 
 ### Signature

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -128,6 +128,7 @@ ttl
 uint
 underspecified
 unencrypted
+unsynchronized
 upgradability
 UX
 vac


### PR DESCRIPTION
Adding the message confirmation packets and the `p2p-request-complete` packet, which were still missing form the ABNF spec.
Decided to move also that mini ABNF spec to where it belongs.
Some minor fixes.
