### PR TITLE
Waku v2 - Historic messages

### DIFF
--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -180,16 +180,12 @@ message Query {
   Cursor cursor = 5;
 }
 
-message Envelope {
-  int32 expiry = 1;
-  int32 ttl = 2;
-  bytes nonce = 3;
-  bytes topic = 4;
-  bytes data = 5;
-}
+// So we need to think about either using `Message` or 
+// having just byte encoded messages and delegating duties
+// to that upwards.
 
 message Response {
-  repeated Envelope envelopes = 1;
+  repeated Message messages = 1;
   Cursor cursor = 2;
 }
 ```

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -148,7 +148,10 @@ TODO(Dean): Fill out this section with historical message API.
 
 ## Changelog
 
-TODO
+TODO(Oskar): Update changelog once we are in draft, which is when
+implementation matches spec
+
+Intial draft version. Released []()
 
 ## Copyright
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -168,6 +168,35 @@ NOTE: This doesn't appear to be documented in PubSub spec, upstream?
 
 ### Historical message support
 
+```protobuf
+message Cursor {
+  bytes before = 1;
+  bytes after = 2;
+}
+
+message Query {
+  int32 from = 1;
+  int32 to = 2;
+  bytes bloom = 3;
+  int32 limit = 4;
+  repeated bytes topics = 5;
+  Cursor cursor = 6;
+}
+
+message Envelope {
+  int32 expiry = 1;
+  int32 ttl = 2;
+  bytes nonce = 3;
+  bytes topic = 4;
+  bytes data = 5;
+}
+
+message Response {
+  repeated Envelope envelopes = 1;
+  Cursor cursor = 2;
+}
+```
+
 TODO(Dean): Fill out this section with historical message API.
 
 - Add issue for this in specs repository

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -65,9 +65,9 @@ TODO
 
 ## Abstract
 
-TODO
+Waku is a privacy-preserving peer-to-peer messaging protocol for resource restricted devices. It implements PubSub in libp2p and adds capabilities on top of it. These capabilities are: (i) retrieving historical messages for mostly-offline devices (ii) adaptive nodes, allowing for heterogenerous nodes to contribute, and (iii) bandwidth preservation for light nodes. This makes it ideal for running a p2p protocol on mobile.
 
-*NOTE: Should highlight things such as mostly-offline bandwidth-constrainted smartphones, historic messages, adaptive nodes, topic interest.*
+Historically, it has its roots in Waku v1 [xx5], which stems from Whisper [xx6], originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See here for a rough road map [xx7].
 
 ## Motivation
 
@@ -130,3 +130,9 @@ xx2: [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/sp
 xx3: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
 
 xx4: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md
+
+xx5: specs.vac.dev/waku/waku.html
+
+xx6: https://eips.ethereum.org/EIPS/eip-627
+
+xx7: https://vac.dev/waku-v2-plan

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -81,11 +81,7 @@ TODO
 
 ## Underlying Transports and Prerequisites
 
-TODO
-
-*NOTE: Should highlight use of libp2p, PubSub (with WakuSub<FloodSub initiailly), and optionally bridging with Waku v1.*
-
-We are using protobuf RPC messages between peers.
+TODO Right now this is more like a set of components
 
 ### Peer Discovery
 
@@ -105,11 +101,37 @@ The current protocol identifier is: `/wakusub/0.0.1` [xx1].
 
 WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will support GossipSub 1 [xx3] and GossipSub 1.1 [xx4].
 
+### Bridge mode
+
+To maintain compatibility with Waku v1, a bridge mode can be achieved. See separate spec.
+
+TODO Detail this in a separate spec
+
 ## Wire Specification
 
-TODO
+We are using protobuf RPC messages between peers. Here's what a message looks like, as defined in the PubSub interface.
+
 
 *NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as the data field for encryption, etc.*
+
+### Messages
+
+```
+message Message {
+	optional string from = 1;
+	optional bytes data = 2;
+	optional bytes seqno = 3;
+	repeated string topicIDs = 4;
+	optional bytes signature = 5;
+	optional bytes key = 6;
+}
+```
+
+TODO Detail options and what's in data, additional methods, etc
+
+### SubOpts
+
+TODO
 
 ## Changelog
 
@@ -119,9 +141,7 @@ TODO
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-## Footnotes
-
-TODO
+## References
 
 xx1: https://docs.libp2p.io/concepts/protocols/
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -175,10 +175,9 @@ message Cursor {
 message Query {
   int32 from = 1;
   int32 to = 2;
-  bytes bloom = 3;
-  int32 limit = 4;
-  repeated bytes topics = 5;
-  Cursor cursor = 6;
+  int32 limit = 3;
+  repeated bytes topics = 4;
+  Cursor cursor = 5;
 }
 
 message Envelope {

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -105,17 +105,25 @@ TODO Detail this in a separate spec
 
 ## Wire Specification
 
-We are using protobuf RPC messages between peers. Here's what a message looks
-like, as defined in the PubSub interface.
+We are using protobuf RPC messages between peers. Here's what the protobuf messages looks like, as defined in the PubSub interface. Please see [PubSub interface spec](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for more details.
 
+In this section we specify two things:
+1) How WakuSub is using these messages.
+2) Additional message types.
 
-*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In
-cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as
-the data field for encryption, etc.*
-
-### Messages
+### Protobuf
 
 ```
+message RPC {
+	repeated SubOpts subscriptions = 1;
+	repeated Message publish = 2;
+
+	message SubOpts {
+		optional bool subscribe = 1;
+		optional string topicid = 2;
+	}
+}
+
 message Message {
 	optional string from = 1;
 	optional bytes data = 2;
@@ -126,11 +134,17 @@ message Message {
 }
 ```
 
-TODO Detail options and what's in data, additional methods, etc
+WakuSub does not currently use the `ControlMessage` defined in GossipSub. However, later versions will add likely add this capability.
 
-### SubOpts
+`TopicDescriptor` as defined in the PubSub interface spec is not currently used.
 
-TODO
+### Historical message support
+
+TODO(Dean): Fill out this section with historical message API.
+
+### Options used
+
+*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as the data field for encryption, etc.*
 
 ## Changelog
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -1,63 +1,9 @@
 ---
 title: Waku
-version: 2.0.0-alpha0
+version: 2.0.0-alpha1
 status: Raw
 authors: Oskar Thorén <oskar@status.im>
 ---
-
-**NOTE: This is a very early raw version of Waku v2 over libp2p**
-
-## General notes and TODOs
-
-### General
-In general, we want to remove as much as possible. WakuSub should be a thin layer on top of PubSub.
-
-A good question to ask: what is the minimal subset we have to support?
-
-How can we defer specific properties to other protocols?
-
-### Data field
-Can we assume data field stays the same? There is nothing in data field about RLPx AFAICT:
-https://github.com/vacp2p/specs/blob/master/specs/waku/envelope-data-format.md
-
-### How do we deal with PoW etc?
-If basically only full nodes set PoW to 0 then it be fine. But if light nodes also set this (afair they do) we have a compatibility issue. Though we also have mailservers.
-
-Simplest might might be to basically send both envelopes, just take out the data thing:
-- v1 [ expiry ttl topic data nonce ]
-- v2 [ ... data ... ]
-
-### Get rid of privileged point of node for RPC?
-We could have JSON RPC for now and then use alt method later. We need to make
-sure the interface with Stimbus and Core/Desktop makes sense.
-
-It'd be useful if a node in browser could use another node without giving away
-private keys (WalletConnect, e.g.).
-
-### Are filters a useful abstraction?
-Not sure I like this filter businesss, just deliver on a topic. If we want to do
-that it can be done separately with a shim and have that specified at a
-different layer. Removing coupling of routing and crypto.
-
-### Consumer spec
-Consumer: https://specs.status.im/spec/10
-
-### Factoring out
-Separate out into constituent pieces, keep main spec small here. What are the pieces?
-- RPC/Node API
-- Filter shim / crypto key compatibility
-- Data field
-- Waku v1 bridge 
-
-### App topics and waku topics
-Ensure path forward for sharding topics. See Eth2 networking spec too.
-
-Ensure topic interest in payload (not for routing, only edge nodes). Current Waku topics.
-
-### Clarity of purpose
-Make it very clear what we provide over e.g. FloodSub.
-- Privacy, resource restriction (offline, topic interest, etc)
-- Thin layer on top of PubSub
 
 ## Table of Contents
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -87,6 +87,10 @@ TODO
 
 We are using protobuf RPC messages between peers.
 
+### Peer Discovery
+
+WakuSub and PubSub don't provide an peer discovery mechanism. This has to be provided for by the environment.
+
 ### PubSub interface
 
 Waku v2 is implementing the PubSub interface in Libp2p. See PubSub spec [xx2] for more details.
@@ -96,6 +100,10 @@ Waku v2 is implementing the PubSub interface in Libp2p. See PubSub spec [xx2] fo
 The current protocol identifier is: `/wakusub/0.0.1` [xx1].
 
 **TODO Update to 2.0.0-alpha0**
+
+### FloodSub
+
+WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will support GossipSub 1 [xx3] and GossipSub 1.1 [xx4].
 
 ## Wire Specification
 
@@ -118,3 +126,7 @@ TODO
 xx1: https://docs.libp2p.io/concepts/protocols/
 
 xx2: [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)
+
+xx3: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
+
+xx4: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -158,7 +158,13 @@ TODO: Don't quite understand this scenario, to clarify. Wouldn't it always be in
 
 ### SubOpts
 
-TODO
+To do topic subscription management, we MAY send updates to our peers. If we do so, then:
+
+The `subscribe` field MUST contain a boolean, where 1 means subscribe and 0 means unsubscribe to a topic.
+
+The `topicid` field MUST contain the topic.
+
+NOTE: This doesn't appear to be documented in PubSub spec, upstream?
 
 ### Historical message support
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -85,9 +85,11 @@ TODO
 
 *NOTE: Should highlight use of libp2p, PubSub (with WakuSub<FloodSub initiailly), and optionally bridging with Waku v1.*
 
-Waku v2 is using PubSub in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01, 958beeed6a90a3cf39db2bb089724d0d44d32296)](https://github.com/libp2p/specs/blob/master/pubsub/README.md** for more details on that.
-
 We are using protobuf RPC messages between peers.
+
+### PubSub interface
+
+Waku v2 is implementing the PubSub interface in Libp2p. See PubSub spec [xx2] for more details.
 
 ### Protocol Identifier
 
@@ -114,3 +116,5 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 TODO
 
 xx1: https://docs.libp2p.io/concepts/protocols/
+
+xx2: [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -27,9 +27,19 @@ authors: Oskar Thorén <oskar@status.im>
 
 ## Abstract
 
-Waku is a privacy-preserving peer-to-peer messaging protocol for resource restricted devices. It implements PubSub over libp2p and adds capabilities on top of it. These capabilities are: (i) retrieving historical messages for mostly-offline devices (ii) adaptive nodes, allowing for heterogeneous nodes to contribute, and (iii) bandwidth preservation for light nodes. This makes it ideal for running a p2p protocol on mobile.
+Waku is a privacy-preserving peer-to-peer messaging protocol for resource
+restricted devices. It implements PubSub over libp2p and adds capabilities on
+top of it. These capabilities are: (i) retrieving historical messages for
+mostly-offline devices (ii) adaptive nodes, allowing for heterogeneous nodes to
+contribute, and (iii) bandwidth preservation for light nodes. This makes it
+ideal for running a p2p protocol on mobile.
 
-Historically, it has its roots in [Waku v1](specs.vac.dev/waku/waku.html), which stems from [Whisper](https://eips.ethereum.org/EIPS/eip-627), originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See [rough road map](https://vac.dev/waku-v2-plan).
+Historically, it has its roots in [Waku v1](specs.vac.dev/waku/waku.html), which
+stems from [Whisper](https://eips.ethereum.org/EIPS/eip-627), originally part of
+the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and
+has a different API. It is implemented in an iterative manner where initial
+focus is on porting essential functionality to libp2p. See [rough road
+map](https://vac.dev/waku-v2-plan).
 
 ## Motivation and goals
 
@@ -63,32 +73,45 @@ TODO Right now this is more like a set of components
 
 ### Peer Discovery
 
-WakuSub and PubSub don't provide an peer discovery mechanism. This has to be provided for by the environment.
+WakuSub and PubSub don't provide an peer discovery mechanism. This has to be
+provided for by the environment.
 
 ### PubSub interface
 
-Waku v2 is implementing the PubSub interface in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for more details.
+Waku v2 is implementing the PubSub interface in Libp2p. See [PubSub interface
+for libp2p (r2,
+2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for
+more details.
 
 ### Protocol Identifier
 
-The current [protocol identifier](https://docs.libp2p.io/concepts/protocols/) is: `/wakusub/2.0.0-alpha1`.
+The current [protocol identifier](https://docs.libp2p.io/concepts/protocols/)
+is: `/wakusub/2.0.0-alpha1`.
 
 ### FloodSub
 
-WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will support [GossipSub v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md) and [GossipSub 1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md).
+WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will
+support [GossipSub
+v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)
+and [GossipSub
+1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md).
 
 ### Bridge mode
 
-To maintain compatibility with Waku v1, a bridge mode can be achieved. See separate spec.
+To maintain compatibility with Waku v1, a bridge mode can be achieved. See
+separate spec.
 
 TODO Detail this in a separate spec
 
 ## Wire Specification
 
-We are using protobuf RPC messages between peers. Here's what a message looks like, as defined in the PubSub interface.
+We are using protobuf RPC messages between peers. Here's what a message looks
+like, as defined in the PubSub interface.
 
 
-*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as the data field for encryption, etc.*
+*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In
+cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as
+the data field for encryption, etc.*
 
 ### Messages
 
@@ -115,17 +138,21 @@ TODO
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 ## References
 
 1. [Protocol Identifiers](https://docs.libp2p.io/concepts/protocols/)
 
-2. [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)
+2. [PubSub interface for libp2p (r2,
+   2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)
 
-3. [GossipSub v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)
+3. [GossipSub
+   v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)
 
-4. [GossipSub v1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md)
+4. [GossipSub
+   v1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md)
 
 5. [Waku v1 spec](specs.vac.dev/waku/waku.html)
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -29,7 +29,7 @@ authors: Oskar Thorén <oskar@status.im>
 
 Waku is a privacy-preserving peer-to-peer messaging protocol for resource restricted devices. It implements PubSub over libp2p and adds capabilities on top of it. These capabilities are: (i) retrieving historical messages for mostly-offline devices (ii) adaptive nodes, allowing for heterogeneous nodes to contribute, and (iii) bandwidth preservation for light nodes. This makes it ideal for running a p2p protocol on mobile.
 
-Historically, it has its roots in Waku v1 [xx5], which stems from Whisper [xx6], originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See here for a rough road map [xx7].
+Historically, it has its roots in [Waku v1](specs.vac.dev/waku/waku.html), which stems from [Whisper](https://eips.ethereum.org/EIPS/eip-627), originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See [rough road map](https://vac.dev/waku-v2-plan).
 
 ## Motivation
 
@@ -51,15 +51,15 @@ WakuSub and PubSub don't provide an peer discovery mechanism. This has to be pro
 
 ### PubSub interface
 
-Waku v2 is implementing the PubSub interface in Libp2p. See PubSub spec [xx2] for more details.
+Waku v2 is implementing the PubSub interface in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for more details.
 
 ### Protocol Identifier
 
-The current protocol identifier is: `/wakusub/2.0.0-alpha1` [xx1].
+The current [protocol identifier](https://docs.libp2p.io/concepts/protocols/) is: `/wakusub/2.0.0-alpha1`.
 
 ### FloodSub
 
-WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will support GossipSub 1 [xx3] and GossipSub 1.1 [xx4].
+WakuSub is currently a subprotocol of FloodSub. Future versions of WakuSub will support [GossipSub v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md) and [GossipSub 1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md).
 
 ### Bridge mode
 
@@ -103,16 +103,16 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 ## References
 
-xx1: https://docs.libp2p.io/concepts/protocols/
+1. [Protocol Identifiers](https://docs.libp2p.io/concepts/protocols/)
 
-xx2: [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)
+2. [PubSub interface for libp2p (r2, 2019-02-01)](https://github.com/libp2p/specs/blob/master/pubsub/README.md)
 
-xx3: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md
+3. [GossipSub v1.0](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.0.md)
 
-xx4: https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md
+4. [GossipSub v1.1](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md)
 
-xx5: specs.vac.dev/waku/waku.html
+5. [Waku v1 spec](specs.vac.dev/waku/waku.html)
 
-xx6: https://eips.ethereum.org/EIPS/eip-627
+6. [Whisper spec (EIP627)](https://eips.ethereum.org/EIPS/eip-627)
 
-xx7: https://vac.dev/waku-v2-plan
+7. [Waku v2 plan](https://vac.dev/waku-v2-plan)

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -8,9 +8,8 @@ authors: Oskar Thorén <oskar@status.im>
 ## Table of Contents
 
 - [Abstract](#abstract)
-- [Motivation](#motivation)
+- [Motivation and goals](#motivation-and-goals)
 - [Definitions](#definitions)
-- [Goals](#goals)
 - [Underlying Transports and Prerequisites](#underlying-transports-and-prerequisites)
   * [Peer Discovery](#peer-discovery)
   * [PubSub interface](#pubsub-interface)
@@ -18,12 +17,13 @@ authors: Oskar Thorén <oskar@status.im>
   * [FloodSub](#floodsub)
   * [Bridge mode](#bridge-mode)
 - [Wire Specification](#wire-specification)
-  * [Messages](#messages)
+  * [Protobuf](#protobuf)
+  * [Message](#message)
   * [SubOpts](#subopts)
+  * [Historical message support](#historical-message-support)
 - [Changelog](#changelog)
 - [Copyright](#copyright)
 - [References](#references)
-
 
 ## Abstract
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -134,17 +134,37 @@ message Message {
 }
 ```
 
-WakuSub does not currently use the `ControlMessage` defined in GossipSub. However, later versions will add likely add this capability.
+WakuSub does not currently use the `ControlMessage` defined in GossipSub.
+However, later versions will add likely add this capability.
 
 `TopicDescriptor` as defined in the PubSub interface spec is not currently used.
+
+### Message
+
+The `from` field MAY indicate which peer is publishing the message.
+
+The `data` field SHOULD be filled out with whatever payload is being sent. Encryption of this field is done at a separate layer.
+
+The `seqno` field MAY be used to provide a linearly increasing number. See PubSub spec for more details.
+
+The `topicIDs` field MUST contain the topics that a message is being published on.
+
+The `signature` field MAY contain the signature of the message, thus providing authentication of the message. See PubSub spec for more details.
+
+The `key` field MAY be present and relates to signing. See PubSub spec for more details.
+
+TODO: Don't quite understand this scenario, to clarify. Wouldn't it always be in `from`?
+> The key field contains the signing key when it cannot be inlined in the source peer ID. When present, it must match the peer ID.
+
+### SubOpts
+
+TODO
 
 ### Historical message support
 
 TODO(Dean): Fill out this section with historical message API.
 
-### Options used
-
-*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as the data field for encryption, etc.*
+- Add issue for this in specs repo
 
 ## Changelog
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -1,0 +1,108 @@
+---
+title: Waku
+version: 2.0.0-alpha0
+status: Raw
+authors: Oskar Thorén <oskar@status.im>
+---
+
+**NOTE: This is a very early raw version of Waku v2 over libp2p**
+
+## General notes and TODOs
+
+### General
+In general, we want to remove as much as possible. WakuSub should be a thin layer on top of PubSub.
+
+A good question to ask: what is the minimal subset we have to support?
+
+How can we defer specific properties to other protocols?
+
+### Data field
+Can we assume data field stays the same? There is nothing in data field about RLPx AFAICT:
+https://github.com/vacp2p/specs/blob/master/specs/waku/envelope-data-format.md
+
+### How do we deal with PoW etc?
+If basically only full nodes set PoW to 0 then it be fine. But if light nodes also set this (afair they do) we have a compatibility issue. Though we also have mailservers.
+
+Simplest might might be to basically send both envelopes, just take out the data thing:
+- v1 [ expiry ttl topic data nonce ]
+- v2 [ ... data ... ]
+
+### Get rid of privileged point of node for RPC?
+We could have JSON RPC for now and then use alt method later. We need to make
+sure the interface with Stimbus and Core/Desktop makes sense.
+
+It'd be useful if a node in browser could use another node without giving away
+private keys (WalletConnect, e.g.).
+
+### Are filters a useful abstraction?
+Not sure I like this filter businesss, just deliver on a topic. If we want to do
+that it can be done separately with a shim and have that specified at a
+different layer. Removing coupling of routing and crypto.
+
+### Consumer spec
+Consumer: https://specs.status.im/spec/10
+
+### Factoring out
+Separate out into constituent pieces, keep main spec small here. What are the pieces?
+- RPC/Node API
+- Filter shim / crypto key compatibility
+- Data field
+- Waku v1 bridge 
+
+### App topics and waku topics
+Ensure path forward for sharding topics. See Eth2 networking spec too.
+
+Ensure topic interest in payload (not for routing, only edge nodes). Current Waku topics.
+
+### Clarity of purpose
+Make it very clear what we provide over e.g. FloodSub.
+- Privacy, resource restriction (offline, topic interest, etc)
+- Thin layer on top of PubSub
+
+## Table of Contents
+
+TODO
+
+## Abstract
+
+TODO
+
+*NOTE: Should highlight things such as mostly-offline bandwidth-constrainted smartphones, historic messages, adaptive nodes, topic interest.*
+
+## Motivation
+
+TODO
+
+*NOTE: Should elaborate on privacy-preserving messaging for resource restricted devices, etc. Also Waku v1 history briefly.*
+
+## Definitions
+
+TODO
+
+## Underlying Transports and Prerequisites
+
+TODO
+
+*NOTE: Should highlight use of libp2p, PubSub (with WakuSub<FloodSub initiailly), and optionally bridging with Waku v1.*
+
+Waku v2 is using PubSub in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01, 958beeed6a90a3cf39db2bb089724d0d44d32296)](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for more details on that.
+
+We are using protobuf RPC messages between peers.
+
+## Wire Specification
+
+TODO
+
+*NOTE: Should contain protobuf definitions that cover essentials of Waku v1. In cases where it doesn't cover, we can defer to siblings/child specs, e.g. such as the data field for encryption, etc.*
+
+## Changelog
+
+TODO
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Footnotes
+
+TODO

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -11,7 +11,7 @@ TODO
 
 ## Abstract
 
-Waku is a privacy-preserving peer-to-peer messaging protocol for resource restricted devices. It implements PubSub in libp2p and adds capabilities on top of it. These capabilities are: (i) retrieving historical messages for mostly-offline devices (ii) adaptive nodes, allowing for heterogenerous nodes to contribute, and (iii) bandwidth preservation for light nodes. This makes it ideal for running a p2p protocol on mobile.
+Waku is a privacy-preserving peer-to-peer messaging protocol for resource restricted devices. It implements PubSub over libp2p and adds capabilities on top of it. These capabilities are: (i) retrieving historical messages for mostly-offline devices (ii) adaptive nodes, allowing for heterogeneous nodes to contribute, and (iii) bandwidth preservation for light nodes. This makes it ideal for running a p2p protocol on mobile.
 
 Historically, it has its roots in Waku v1 [xx5], which stems from Whisper [xx6], originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See here for a rough road map [xx7].
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -85,9 +85,15 @@ TODO
 
 *NOTE: Should highlight use of libp2p, PubSub (with WakuSub<FloodSub initiailly), and optionally bridging with Waku v1.*
 
-Waku v2 is using PubSub in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01, 958beeed6a90a3cf39db2bb089724d0d44d32296)](https://github.com/libp2p/specs/blob/master/pubsub/README.md) for more details on that.
+Waku v2 is using PubSub in Libp2p. See [PubSub interface for libp2p (r2, 2019-02-01, 958beeed6a90a3cf39db2bb089724d0d44d32296)](https://github.com/libp2p/specs/blob/master/pubsub/README.md** for more details on that.
 
 We are using protobuf RPC messages between peers.
+
+### Protocol Identifier
+
+The current protocol identifier is: `/wakusub/0.0.1` [xx1].
+
+**TODO Update to 2.0.0-alpha0**
 
 ## Wire Specification
 
@@ -106,3 +112,5 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 ## Footnotes
 
 TODO
+
+xx1: https://docs.libp2p.io/concepts/protocols/

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -7,7 +7,23 @@ authors: Oskar Thorén <oskar@status.im>
 
 ## Table of Contents
 
-TODO
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Definitions](#definitions)
+- [Goals](#goals)
+- [Underlying Transports and Prerequisites](#underlying-transports-and-prerequisites)
+  * [Peer Discovery](#peer-discovery)
+  * [PubSub interface](#pubsub-interface)
+  * [Protocol Identifier](#protocol-identifier)
+  * [FloodSub](#floodsub)
+  * [Bridge mode](#bridge-mode)
+- [Wire Specification](#wire-specification)
+  * [Messages](#messages)
+  * [SubOpts](#subopts)
+- [Changelog](#changelog)
+- [Copyright](#copyright)
+- [References](#references)
+
 
 ## Abstract
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -31,11 +31,27 @@ Waku is a privacy-preserving peer-to-peer messaging protocol for resource restri
 
 Historically, it has its roots in [Waku v1](specs.vac.dev/waku/waku.html), which stems from [Whisper](https://eips.ethereum.org/EIPS/eip-627), originally part of the Ethereum stack. However, Waku v2 acts more as a thin wrapper for PubSub and has a different API. It is implemented in an iterative manner where initial focus is on porting essential functionality to libp2p. See [rough road map](https://vac.dev/waku-v2-plan).
 
-## Motivation
+## Motivation and goals
 
-TODO
+1. **Generalized messaging.** Many applications requires some form of messaging
+   protocol to communicate between different subsystems or different nodes. This
+   messaging can be human-to-human or machine-to-machine or a mix.
 
-*NOTE: Should elaborate on privacy-preserving messaging for resource restricted devices, etc. Also Waku v1 history briefly.*
+2. **Peer-to-peer.**These applications sometimes have requirements that make
+   them suitable for peer-to-peer solutions.
+
+3. **Resource restricted**.These applications often run in constrained
+   environments, where resources or the environment is restricted in some
+   fashion. E.g.:
+
+- limited bandwidth, cpu, memory, disk, battery, etc
+- not being publicly connectable
+- only being intermittently connected; mostly-offline
+
+4. **Privacy.** These applications have a desire for some privacy guarantees,
+   such as pseudonymity, metadata protection in transit, etc.
+
+Waku provides a solution that satisfies these goals in a reasonable matter.
 
 ## Definitions
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -39,9 +39,7 @@ Waku v2 is implementing the PubSub interface in Libp2p. See PubSub spec [xx2] fo
 
 ### Protocol Identifier
 
-The current protocol identifier is: `/wakusub/0.0.1` [xx1].
-
-**TODO Update to 2.0.0-alpha0**
+The current protocol identifier is: `/wakusub/2.0.0-alpha1` [xx1].
 
 ### FloodSub
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -54,7 +54,7 @@ map](https://vac.dev/waku-v2-plan).
    environments, where resources or the environment is restricted in some
    fashion. E.g.:
 
-- limited bandwidth, cpu, memory, disk, battery, etc
+- limited bandwidth, CPU, memory, disk, battery, etc
 - not being publicly connectable
 - only being intermittently connected; mostly-offline
 

--- a/specs/waku/waku-v2.md
+++ b/specs/waku/waku-v2.md
@@ -170,14 +170,14 @@ NOTE: This doesn't appear to be documented in PubSub spec, upstream?
 
 TODO(Dean): Fill out this section with historical message API.
 
-- Add issue for this in specs repo
+- Add issue for this in specs repository
 
 ## Changelog
 
 TODO(Oskar): Update changelog once we are in draft, which is when
 implementation matches spec
 
-Intial draft version. Released []()
+Initial draft version. Released []()
 
 ## Copyright
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -19,6 +19,7 @@ boolean
 Briar
 BSP
 cas
+changelog
 Changelog
 COSS
 CPU
@@ -53,6 +54,7 @@ html
 http
 https
 im
+inlined
 invariants
 ip
 IPs

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -21,6 +21,7 @@ BSP
 cas
 Changelog
 COSS
+CPU
 DAG
 DAGs
 Dapp
@@ -42,6 +43,7 @@ enum
 et
 Ethereum
 extensibility
+FloodSub
 GCM
 github
 GossipSub
@@ -94,6 +96,7 @@ PoW
 proto
 protobuf
 PSS
+pseudonymity
 PubSub
 pyspelling
 qNAN

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -44,6 +44,7 @@ Ethereum
 extensibility
 GCM
 github
+GossipSub
 growable
 hasherror
 html
@@ -93,6 +94,7 @@ PoW
 proto
 protobuf
 PSS
+PubSub
 pyspelling
 qNAN
 remoteHash
@@ -113,6 +115,7 @@ seqid
 Sieka
 sNAN
 suboptimal
+SubOpts
 subprotocol
 subprotocols
 TBD
@@ -135,6 +138,7 @@ vacp
 vacp2p
 Vp
 waku
+WakuSub
 WakuWhisper
 wms
 wns

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -115,6 +115,7 @@ scalability
 SECP
 semver
 seqid
+seqno
 Sieka
 sNAN
 suboptimal
@@ -124,6 +125,7 @@ subprotocols
 TBD
 TCP
 textlint
+topicIDs
 Thorén
 tla
 tls


### PR DESCRIPTION
This pull request is the new spec for the historic messages system, which is the mailserver successor. The related issue is: https://github.com/status-im/nim-waku/issues/38

Addresses https://github.com/vacp2p/specs/issues/157