### PR TITLE
Waku message spec

### DIFF
--- a/specs/waku/README.md
+++ b/specs/waku/README.md
@@ -12,3 +12,4 @@
   - [waku/2 filter](./v2/waku-filter.md) spec for WakuFilter, alpha
   - [waku/2 store](./v2/waku-store.md) spec for WakuStore, alpha
   - [waku/2 bridge](./v2/waku-bridge.md) spec for Waku bridge with v1, alpha
+  - [waku/2 message](./v2/waku-message.md) spec for Waku Message, alpha

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -37,9 +37,9 @@ This specification attempts to provide for these various requirements.
 
 A `WakuMessage` is what is being passed around by the other protocols, such as WakuRelay, WakuStore, and WakuFilter.
 
-The `payload` field SHOULD contain whatever payload is being sent. Encryption of this field MAY be done at a separate layer.
+The `payload` field SHOULD contain whatever payload is being sent. See section below on payload encryption.
 
-The `contentTopic` field SHOULD be filled out to allow for content-based filtering (see section below).
+The `contentTopic` field SHOULD be filled out to allow for content-based filtering. See [Waku Filter spec](waku-filter.md) for details.
 
 The `version` field SHOULD be filled out to allow for various types of payload encryption.
 

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -55,7 +55,7 @@ message WakuMessage {
 
 ## Payload encryption
 
-Payload encryption depends on which `version` field is set.
+Payload encryption depends on the `version` field.
 
 ### Version 0
 

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -1,0 +1,53 @@
+---
+title: Waku Message
+version: 2.0.0-alpha1
+status: Raw
+authors: Oskar Thorén <oskar@status.im>
+---
+
+# Table of Contents
+
+TODO
+
+# Abstract
+
+TODO
+
+# Motivation
+
+TODO
+
+## WakuMessage
+
+A `WakuMessage` is what is being passed around by the other protocols, such as WakuRelay, WakuStore, and WakuFilter.
+
+The `payload` field SHOULD contain whatever payload is being sent. Encryption of this field is done at a separate layer.
+
+The `contentTopic` field SHOULD be filled out to allow for content-based filtering (see section below).
+
+
+## Protobuf
+
+```protobuf
+message WakuMessage {
+  optional bytes payload = 1;
+  optional string contentTopic = 2;
+}
+```
+
+# Differences from Whisper / Waku v1 envelopes
+
+In Whisper and Waku v1, an envelope contains the following fields: `expiry, ttl,
+topic, data, nonce`.
+
+Since Waku v2 is using libp2p PubSub, some of these fields can be dropped. The previous `topic`
+field corresponds to `contentTopic`. The previous `data` field corresponds to the `payload` field.
+
+# Changelog
+
+TODO
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -7,7 +7,16 @@ authors: Oskar Thorén <oskar@status.im>
 
 # Table of Contents
 
-TODO
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+    - [WakuMessage](#wakumessage)
+    - [Protobuf](#protobuf)
+    - [Payload encryption](#payload-encryption)
+        - [Version 0](#version-0)
+        - [Version 1](#version-1)
+- [Differences from Whisper / Waku v1 envelopes](#differences-from-whisper--waku-v1-envelopes)
+- [Changelog](#changelog)
+- [Copyright](#copyright)
 
 # Abstract
 
@@ -69,7 +78,7 @@ field corresponds to `contentTopic`. The previous `data` field corresponds to th
 
 # Changelog
 
-TODO
+Initial release on [](TODO).
 
 # Copyright
 

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -11,20 +11,28 @@ TODO
 
 # Abstract
 
-TODO
+This specification provides a way to encapsulate messages sent over Waku with specific information security goals.
 
 # Motivation
 
-TODO
+When using Waku to send messages over Waku there are multiple concerns:
+- We may have a separate encryption layer as part of our application
+- We may want to provide efficient routing for resource restricted devices
+- We may want to provide compatibility with Waku v1 envelopes
+- We may want payloads to be encrypted by default
+- We may want to provide unlinkability for metadata protection
+
+This specification attempts to provide for these various requirements.
 
 ## WakuMessage
 
 A `WakuMessage` is what is being passed around by the other protocols, such as WakuRelay, WakuStore, and WakuFilter.
 
-The `payload` field SHOULD contain whatever payload is being sent. Encryption of this field is done at a separate layer.
+The `payload` field SHOULD contain whatever payload is being sent. Encryption of this field MAY be done at a separate layer.
 
 The `contentTopic` field SHOULD be filled out to allow for content-based filtering (see section below).
 
+The `version` field SHOULD be filled out to allow for various types of payload encryption.
 
 ## Protobuf
 
@@ -32,8 +40,24 @@ The `contentTopic` field SHOULD be filled out to allow for content-based filteri
 message WakuMessage {
   optional bytes payload = 1;
   optional string contentTopic = 2;
+  optional string version = 3;
 }
 ```
+
+## Payload encryption
+
+Payload encryption depends on which `version` field is set.
+
+### Version 0
+
+This indicates that the payload SHOULD be either unencrypted or that encryption is done at a separate layer outside of Waku.
+
+### Version 1
+
+This indicates that payloads MUST be encrypted using [Waku v1 envelope data
+format spec](../v1/envelope-data-format.md).
+
+This provides for asymmetric and symmetric encryption. Key agreement is out of band. It also provides an encrypted signature and padding for some form of unlinkability.
 
 # Differences from Whisper / Waku v1 envelopes
 

--- a/specs/waku/v2/waku-message.md
+++ b/specs/waku/v2/waku-message.md
@@ -41,7 +41,7 @@ The `payload` field SHOULD contain whatever payload is being sent. See section b
 
 The `contentTopic` field SHOULD be filled out to allow for content-based filtering. See [Waku Filter spec](waku-filter.md) for details.
 
-The `version` field SHOULD be filled out to allow for various types of payload encryption.
+The `version` field MAY be filled out to allow for various types of payload encryption. Omitting it means the version is 0.
 
 ## Protobuf
 

--- a/specs/waku/v2/waku-relay.md
+++ b/specs/waku/v2/waku-relay.md
@@ -1,6 +1,6 @@
 ---
-title: Waku
-version: 2.0.0-beta1
+title: Waku Relay
+version: 2.0.0-beta2
 status: Draft
 authors: Oskar Thorén <oskar@status.im>
 ---
@@ -20,7 +20,7 @@ authors: Oskar Thorén <oskar@status.im>
 
 `WakuRelay` is part of the gossip domain for Waku. It is a thin layer on top of GossipSub.
 
-**Protocol identifier***: `/vac/waku/relay/2.0.0-beta1`
+**Protocol identifier***: `/vac/waku/relay/2.0.0-beta2`
 
 ## Wire Specification
 
@@ -48,11 +48,6 @@ message Message {
   optional bytes signature = 5;
   optional bytes key = 6;
 }
-
-message WakuMessage {
-  optional bytes payload = 1;
-  optional string contentTopic = 2;
-}
 ```
 
 WakuSub does not currently use the `ControlMessage` defined in GossipSub.
@@ -69,7 +64,7 @@ gossiped. See section below on how the fields work.
 
 The `from` field MAY indicate which peer is publishing the message.
 
-The `data` field SHOULD be filled out with a `WakuMessage`.
+The `data` field MUST be filled out with a `WakuMessage`. See the [Waku Message](waku-message.md) spec for more details.
 
 The `seqno` field MAY be used to provide a linearly increasing number. See PubSub spec for more details.
 
@@ -88,15 +83,14 @@ The `subscribe` field MUST contain a boolean, where 1 means subscribe and 0 mean
 
 The `topicid` field MUST contain the topic.
 
-## WakuMessage
-
-A `WakuMessage` SHOULD be in the `data` field of `Message`.
-
-The `payload` field SHOULD contain whatever payload is being sent. Encryption of this field is done at a separate layer.
-
-The `contentTopic` field SHOULD be filled out to allow for content-based filtering (see section below).
-
 ## Changelog
+
+### 2.0.0-beta2
+
+Next version. Changes:
+
+- Moved WakuMessage to separate spec and made it mandatory
+
 
 ### 2.0.0-beta1
 
@@ -129,6 +123,4 @@ TODO: Don't quite understand this scenario [key field], to clarify. Wouldn't it 
 
 Re topicid:
 NOTE: This doesn't appear to be documented in PubSub spec, upstream?
-
-TODO: Find place for WakuMessage
 -->

--- a/specs/waku/v2/waku-v2.md
+++ b/specs/waku/v2/waku-v2.md
@@ -74,6 +74,9 @@ The current [protocol identifiers](https://docs.libp2p.io/concepts/protocols/) a
 
 These protocols and their semantics are elaborated on in their own specs.
 
+For the actual content being passed around, see the [Waku
+Message](waku-message.md) spec.
+
 ## Gossip domain
 
 **Protocol identifier***: `/vac/waku/relay/2.0.0-beta1`

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -159,6 +159,7 @@ trilemma
 ttl
 uint
 underspecified
+unlinkability
 unencrypted
 unsynchronized
 upgradability


### PR DESCRIPTION
Addresses the following issues:
- https://github.com/vacp2p/specs/issues/198
- https://github.com/vacp2p/specs/issues/194

As well as, at least for the time being:
- https://github.com/vacp2p/specs/issues/181
- https://github.com/vacp2p/specs/issues/158

This would later evolve into research issue https://github.com/vacp2p/specs/issues/182, but that's for later.