### PR TITLE
Add Admin API

### DIFF
--- a/specs/waku/v2/waku-v2-rpc-api.md
+++ b/specs/waku/v2/waku-v2-rpc-api.md
@@ -284,6 +284,34 @@ The `get_waku_v2_filter_v1_messages` method returns a list of messages that were
 
 - **`Array`[[`WakuMessage`](#WakuMessage)]** - the latest `messages` on the polled content `topic` or an [error](https://www.jsonrpc.org/specification#error_object) on failure.
 
+## Admin API
+
+The Admin API provides privileged accesses to the internal operations of a Waku v2 node.
+
+### Types
+
+The following structured types are defined for use on the Admin API:
+
+#### WakuPeer
+
+`WakuPeer` is an `Object` containing the following fields:
+| Field | Type | Inclusion | Description |
+| ----: | :--: | :--: |----------- |
+| `listenStr` | `String` | mandatory | Address that this peer is listening for |
+| `protocol` | `String` | mandatory | Protocol that this peer is registered for |
+| `connected` | `bool` | mandatory | `true` if peer has active connection for this `protocol`, `false` if not |
+
+### `get_waku_v2_admin_v1_peers`
+
+The `get_waku_v2_admin_v1_peers` method returns an array of peers registered on this node. Since a Waku v2 node may open either continuous or ad-hoc connections, depending on the negotiated protocol, these peers may have different connected states. The same peer MAY appear twice in the returned array, if it is registered for more than one protocol.
+
+#### Parameters
+
+none
+
+#### Response
+- **`Array`[[`WakuPeer`](#WakuPeer)]** - Array of peers registered on this node
+
 # Example usage
 
 ## Store API

--- a/specs/waku/v2/waku-v2-rpc-api.md
+++ b/specs/waku/v2/waku-v2-rpc-api.md
@@ -297,7 +297,7 @@ The following structured types are defined for use on the Admin API:
 `WakuPeer` is an `Object` containing the following fields:
 | Field | Type | Inclusion | Description |
 | ----: | :--: | :--: |----------- |
-| `listenStr` | `String` | mandatory | Address that this peer is listening for |
+| `multiaddr` | `String` | mandatory | Multiaddress containing this peer's location and identity |
 | `protocol` | `String` | mandatory | Protocol that this peer is registered for |
 | `connected` | `bool` | mandatory | `true` if peer has active connection for this `protocol`, `false` if not |
 

--- a/specs/waku/v2/waku-v2-rpc-api.md
+++ b/specs/waku/v2/waku-v2-rpc-api.md
@@ -303,7 +303,7 @@ The following structured types are defined for use on the Admin API:
 
 ### `get_waku_v2_admin_v1_peers`
 
-The `get_waku_v2_admin_v1_peers` method returns an array of peers registered on this node. Since a Waku v2 node may open either continuous or ad-hoc connections, depending on the negotiated protocol, these peers may have different connected states. The same peer MAY appear twice in the returned array, if it is registered for more than one protocol.
+The `get_waku_v2_admin_v1_peers` method returns an array of peers registered on this node. Since a Waku v2 node may open either continuous or ad hoc connections, depending on the negotiated protocol, these peers may have different connected states. The same peer MAY appear twice in the returned array, if it is registered for more than one protocol.
 
 #### Parameters
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -70,6 +70,7 @@ HistoryQuery
 historyResponse
 HistoryResponse
 HistoryRPC
+hoc
 html
 http
 https
@@ -205,6 +206,7 @@ waku
 WakuFilter
 WakuInfo
 WakuMessage
+WakuPeer
 WakuRelay
 WakuRelayMessage
 WakuStore


### PR DESCRIPTION
This PR partially addresses #259. It proposes a way to retrieve information about peers from a Waku v2 node over the Admin API

#### Rationale

@jakubgs suggested that it may be useful to see information about connected peers over the Admin API. This PR adds a method that returns a list of "registered" peers on the node, i.e. bundling static nodes, swap nodes, filter nodes and store nodes together, regardless of `connected`-status. This does not prohibit us from adding parameters in future that will filter the output on protocol or `connected`-status.

#### Implementation notes

- `wakunode2` does not currently keep track of connections. A proper implementation may require at least partially addressing peer pool/peer management issues (https://github.com/status-im/nim-waku/issues/265, https://github.com/status-im/nim-libp2p/issues/438). This will also open up more advanced Admin API capabilities, such as triggering peer reconnection, adding peer nodes, etc.
- swap nodes, filter nodes and store nodes already keep track of peers