### PR TITLE
Feature/add private api

### DIFF
--- a/specs/waku/v2/waku-v2-rpc-api.md
+++ b/specs/waku/v2/waku-v2-rpc-api.md
@@ -344,7 +344,7 @@ none
 
 ### `get_waku_v2_private_v1_keypair`
 
-Generates and returns a public/private key pair that can be used for assymetric message encryption and decryption.
+Generates and returns a public/private key pair that can be used for asymmetric message encryption and decryption.
 
 #### Parameters
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -37,6 +37,7 @@ DDoS
 De
 decrypt
 decrypted
+decrypts
 dereference
 deserialized
 devp
@@ -87,6 +88,7 @@ Kademlia
 keccak
 Keccak
 keypair
+KeyPair
 kimdemey
 Lange
 libp
@@ -109,6 +111,7 @@ mixnet
 mixnets
 Mscgen
 multiaddr
+Multiaddress
 mvds
 NameInit
 NameUpdate
@@ -194,6 +197,7 @@ underspecified
 unlinkability
 unencrypted
 unsynchronized
+untrusted
 upgradability
 uuid
 UUID


### PR DESCRIPTION
This PR closes https://github.com/vacp2p/specs/issues/258

It describes a "Private" API for Waku v2 nodes to allow backwards compatibility with Waku v1 payload encryption/decryption.
- The API provides methods for clients to generate their own symkeys or asymmetric key pairs, depending on the preferred type of cryptography, and to use those when relaying messages or reading from subscribed topics.
- Clients are responsible to store and keep track of their own keys. This implies that the relevant encryption/decryption keys must be provided whenever messages are relayed/read, but this approach obviates the need for a risky `KeyStorage` on the server.