### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Waku is a protocol that replaces Whisper ([EIP-627](https://eips.ethereum.org/EI
   - [waku/2 bridge](./v2/waku/waku-bridge.md) spec for Waku bridge with v1, alpha
 
 #### Version 0 and 1
- - [waku/0](./v1/waku-0.md) specs for `waku/0` version, now deprecated
- - [waku/1](./v1/waku-1.md) specs for `waku/1` version, current stable version
- - [envelope data format](./v1/envelope-data-format.md) [waku](./waku.md) envelope data field specification.
- - [mailserver](./v1/mailserver.md) - Mailserver specification for archiving and delivering historical [waku](./waku.md) envelopes on demand.
- - [rpc api](./v1/waku-rpc-api.md) - Waku RPC API for Waku v1 nodes.
+ - [waku/0](./waku/v1/waku-0.md) specs for `waku/0` version, now deprecated
+ - [waku/1](./waku/v1/waku-1.md) specs for `waku/1` version, current stable version
+ - [envelope data format](./waku/v1/envelope-data-format.md) [waku](./waku/waku.md) envelope data field specification.
+ - [mailserver](./waku/v1/mailserver.md) - Mailserver specification for archiving and delivering historical [waku](./waku/waku.md) envelopes on demand.
+ - [rpc api](./waku/v1/waku-rpc-api.md) - Waku RPC API for Waku v1 nodes.
 
 ### Data sync
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These protocols define various components of the [vac](https://vac.dev) stack.
 
 ### Waku
 
-Waku is a protocol that replaces Whisper ([EIP-627](https://eips.ethereum.org/EIPS/eip-627)). Waku v2 is an upgrade of Waku v1 that is in active development and offfer significant improvements. You can read more about the [plan for it](https://vac.dev/waku-v2-plan) and an [update](https://vac.dev/waku-v2-update).
+Waku is a protocol that replaces Whisper ([EIP-627](https://eips.ethereum.org/EIPS/eip-627)). Waku v2 is an upgrade of Waku v1 that is in active development and offer significant improvements. You can read more about the [plan for it](https://vac.dev/waku-v2-plan) and an [update](https://vac.dev/waku-v2-update).
 
 #### Version 2
   - [waku/2](./waku/v2/waku-v2.md) specs for `waku/2` version, current draft version

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Waku is a protocol that replaces Whisper ([EIP-627](https://eips.ethereum.org/EI
   - [waku/2 filter](./waku/v2/waku-filter.md) spec for WakuFilter, current draft version
   - [waku/2 store](./waku/v2/waku-store.md) spec for WakuStore, current draft version
   - [waku/2 message](./waku/v2/waku-message.md) spec for Waku Message, current draft version
-  - [waku/2 bridge](./v2/waku/waku-bridge.md) spec for Waku bridge with v1, alpha
+  - [waku/2 bridge](./waku/v2/waku-bridge.md) spec for Waku bridge with v1, alpha
+  - [waku/2 rln relay](./waku/v2/waku-rln-relay.md) spec for Waku Relay with RLN, alpha
+  - [waku/2 swap](./waku/v2/waku-swap-accounting.md) spec for Waku Swap Accounting, alpha
+  - [waku/2 rpc api](./waku/v2/waku-rpc-api.md) - Waku RPC API for Waku v2 nodes, alpha
 
 #### Version 0 and 1
  - [waku/0](./waku/v1/waku-0.md) specs for `waku/0` version, now deprecated

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/vacp2p/specs/workflows/CI/badge.svg)
+<!-- [CI](https://github.com/vacp2p/specs/workflows/CI/badge.svg) -->
 
 This repository contains the specs for [vac](https://vac.dev), a modular peer-to-peer messaging stack, with a focus on secure messaging. A detailed explanation of the vac and its design goals can be found [here](https://vac.dev/vac-overview).
 
@@ -10,11 +10,24 @@ The entire vac protocol is under active development, each specification has its 
 
 These protocols define various components of the [vac](https://vac.dev) stack.
 
-## Waku
+### Waku
 
-Waku is a protocol that substitutes [EIP-627](https://eips.ethereum.org/EIPS/eip-627). Waku v2 is in development. Here you can read more about the [plan for it](https://vac.dev/waku-v2-plan) and an [update](https://vac.dev/waku-v2-update).
+Waku is a protocol that replaces Whisper ([EIP-627](https://eips.ethereum.org/EIPS/eip-627)). Waku v2 is an upgrade of Waku v1 that is in active development and offfer significant improvements. You can read more about the [plan for it](https://vac.dev/waku-v2-plan) and an [update](https://vac.dev/waku-v2-update).
 
-Waku is made up of several protocols and specifications. To see them go to the [Waku spec home](https://specs.vac.dev/specs/waku/).
+#### Version 2
+  - [waku/2](./waku/v2/waku-v2.md) specs for `waku/2` version, current draft version
+  - [waku/2 relay](./waku/v2/waku-relay.md) spec for WakuRelay, current draft version
+  - [waku/2 filter](./waku/v2/waku-filter.md) spec for WakuFilter, current draft version
+  - [waku/2 store](./waku/v2/waku-store.md) spec for WakuStore, current draft version
+  - [waku/2 message](./waku/v2/waku-message.md) spec for Waku Message, current draft version
+  - [waku/2 bridge](./v2/waku/waku-bridge.md) spec for Waku bridge with v1, alpha
+
+#### Version 0 and 1
+ - [waku/0](./v1/waku-0.md) specs for `waku/0` version, now deprecated
+ - [waku/1](./v1/waku-1.md) specs for `waku/1` version, current stable version
+ - [envelope data format](./v1/envelope-data-format.md) [waku](./waku.md) envelope data field specification.
+ - [mailserver](./v1/mailserver.md) - Mailserver specification for archiving and delivering historical [waku](./waku.md) envelopes on demand.
+ - [rpc api](./v1/waku-rpc-api.md) - Waku RPC API for Waku v1 nodes.
 
 ### Data sync
 


### PR DESCRIPTION
https://specs.vac.dev/ is a bit hard to get to Waku v2 specs, this attempts to fix it and cleans it up a bit.

A red CI icon isn't the first thing you want to see going to specs.vac.dev either, so commented this out. CI "breaking" for specs doesn't really impact things materially.