### PR TITLE
Bump 16/WAKU2-RPC to draft

### DIFF
--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -2,7 +2,7 @@
 slug: 16
 title: 16/WAKU2-RPC
 name: Waku v2 RPC API
-status: raw
+status: draft
 editor: Hanno Cornelius <hanno@status.im>
 ---
 
@@ -619,10 +619,6 @@ This method is part of the `store` API and the specific resources to retrieve ar
 1. [LibP2P Addressing](https://docs.libp2p.io/concepts/addressing/)
 1. [LibP2P PubSub specification - topic descriptor](https://github.com/libp2p/specs/tree/master/pubsub#the-topic-descriptor)
 1. [Waku v2 specification](https://github.com/vacp2p/specs/blob/master/specs/waku/v2/waku-v2.md)
-
-# Changelog
-
-TBD
 
 # Copyright
 


### PR DESCRIPTION
This PR closes #321

It bumps 16/WAKU2-RPC from `raw` to `draft`, since all specified calls are implemented/can be demonstrated.
I've also removed the `Changelog` section in accordance with our simplified spec lifecycle.