### PR TITLE
Some fixes on the store protocol specs

### DIFF
--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -42,7 +42,7 @@ message Index {
 }
 
 message PagingInfo {
-  int64 pageSize = 1;
+  uint64 pageSize = 1;
   Index cursor = 2;
   enum Direction {
     FORWARD = 1;

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -45,8 +45,8 @@ message PagingInfo {
   int64 pageSize = 1;
   Index cursor = 2;
   enum Direction {
-    FORWARD = 0;
-    BACKWARD = 1;
+    FORWARD = 1;
+    BACKWARD = 0;
   }
   Direction direction = 3;
 }

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -45,8 +45,8 @@ message PagingInfo {
   uint64 pageSize = 1;
   Index cursor = 2;
   enum Direction {
-    FORWARD = 1;
     BACKWARD = 0;
+    FORWARD = 1;
   }
   Direction direction = 3;
 }


### PR DESCRIPTION
## Problem
This PR is going to address some of the inconsistencies in the store protocol specs as outlined in https://github.com/vacp2p/rfc/issues/326
that includes:
1. changes the `pageSize` from `int64` to `uint64`. Corresponding implementation PR https://github.com/status-im/nim-waku/pull/469
2. Fixes the paging direction enum (swaps the order of `BACKWARD` and `FORWARD`). This change complies with the current implementation.
