### PR TITLE
12/WAKU2-FILTER: contentFilter to string

### DIFF
--- a/content/docs/rfcs/10/README.md
+++ b/content/docs/rfcs/10/README.md
@@ -107,7 +107,7 @@ See [13/WAKU2-STORE](/spec/13) spec for more details.
 
 **Protocol identifier***: `/vac/waku/filter/2.0.0-beta1`
 
-See [14/WAKU2-FILTER](/spec/14) spec for more details.
+See [12/WAKU2-FILTER](/spec/12) spec for more details.
 
 ## Overview
 

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -65,7 +65,7 @@ message FilterRequest {
   repeated ContentFilter contentFilters = 3;
 
   message ContentFilter {
-    repeated uint32 contentTopics = 1;
+    repeated string contentTopics = 1;
   }
 }
 


### PR DESCRIPTION
- Missed one protobuf for changing `contentFilter` to `string`.
- Fixed one reference to 12/WAKU2-FILTER