### PR TITLE
Store protocol hash type and inputs

### DIFF
--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -89,8 +89,8 @@ message HistoryRPC {
 ### Index
 
 To perform pagination, each `WakuMessage` stored at a node running the `13/WAKU2-STORE` protocol is associated with a unique `Index` that encapsulates the following parts. 
-- `digest`:  a sequence of bytes representing the hash of a `WakuMessage`.
-  The hash value is computed using SHA256.
+- `digest`:  a sequence of bytes representing the SHA256 hash of a `WakuMessage`.
+  The hash is computed over the concatenation of `contentTopic` and `payload` fields of a `WakuMessage` (see [14/WAKU2-MESSAGE](/spec/14)).
 - `receivedTime`: the UNIX time at which the waku message is received by the node running the `13/WAKU2-STORE` protocol.
 
 ### PagingInfo

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -90,6 +90,7 @@ message HistoryRPC {
 
 To perform pagination, each `WakuMessage` stored at a node running the `13/WAKU2-STORE` protocol is associated with a unique `Index` that encapsulates the following parts. 
 - `digest`:  a sequence of bytes representing the hash of a `WakuMessage`.
+  The hash value is computed using SHA256.
 - `receivedTime`: the UNIX time at which the waku message is received by the node running the `13/WAKU2-STORE` protocol.
 
 ### PagingInfo


### PR DESCRIPTION
Closes https://github.com/vacp2p/rfc/issues/301. 
Also, specifies the inputs to the hash function for the computation of message digest.