### PR TITLE
Add pubsub topic to store json rpc api

### DIFF
--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -218,6 +218,7 @@ The `get_waku_v2_store_v1_messages` method retrieves historical messages on spec
 
 | Field | Type | Inclusion | Description |
 | ----: | :---: | :---: |----------- |
+| `pubsubTopic` | `String`| mandatory | The pubsub topic on which a  [`WakuMessage`](#WakuMessage) is published|
 | `contentFilters` | `Array`[[`ContentFilter`](#contentfilter)] | mandatory | Array of content filters to query for historical messages |
 | `pagingOptions` | [`PagingOptions`](#PagingOptions) | optional | Pagination information |
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -452,7 +452,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
 
 #### Request
 
-```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":[["/waku/2/default-content/proto"]]}' --header "Content-Type: application/json" http://localhost:8545```
+```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":["", ["/waku/2/default-content/proto"]]}' --header "Content-Type: application/json" http://localhost:8545```
 
 ```jsonrpc
 {
@@ -460,6 +460,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
   "id": "id",
   "method": "get_waku_v2_store_v1_messages",
   "params": [
+    "",
     [
       {"contentTopic": "/waku/2/default-content/proto"}
     ]
@@ -509,7 +510,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
 
 #### Request
 
-```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":[["/waku/2/default-content/proto"],{"pageSize":2,"forward":false}]}' --header "Content-Type: application/json" http://localhost:8545```
+```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":[ "", ["/waku/2/default-content/proto"],{"pageSize":2,"forward":false}]}' --header "Content-Type: application/json" http://localhost:8545```
 
 ```jsonrpc
 {
@@ -517,6 +518,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
   "id": "id",
   "method": "get_waku_v2_store_v1_messages",
   "params": [
+    "",
     [
       {"contentTopic": "/waku/2/default-content/proto"}
     ],
@@ -570,7 +572,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
 
 #### Request
 
-```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":[["/waku/2/default-content/proto"],{"pageSize":2,"cursor":{"digest":"abcdef","receivedTime":1605887187.00},"forward":false}]}' --header "Content-Type: application/json" http://localhost:8545```
+```curl -d '{"jsonrpc":"2.0","id":"id","method":"get_waku_v2_store_v1_messages", "params":[ "", ["/waku/2/default-content/proto"],{"pageSize":2,"cursor":{"digest":"abcdef","receivedTime":1605887187.00},"forward":false}]}' --header "Content-Type: application/json" http://localhost:8545```
 
 ```jsonrpc
 {
@@ -578,6 +580,7 @@ This method is part of the `store` API and the specific resources to retrieve ar
   "id": "id",
   "method": "get_waku_v2_store_v1_messages",
   "params": [
+    "",
     [
       {"contentTopic": "/waku/2/default-content/proto"}
     ],

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -218,7 +218,7 @@ The `get_waku_v2_store_v1_messages` method retrieves historical messages on spec
 
 | Field | Type | Inclusion | Description |
 | ----: | :---: | :---: |----------- |
-| `pubsubTopic` | `String`| mandatory | The pubsub topic on which a  [`WakuMessage`](#WakuMessage) is published|
+| `pubsubTopic` | `String` | mandatory | The pubsub topic on which a  [`WakuMessage`](#WakuMessage) is published|
 | `contentFilters` | `Array`[[`ContentFilter`](#contentfilter)] | mandatory | Array of content filters to query for historical messages |
 | `pagingOptions` | [`PagingOptions`](#PagingOptions) | optional | Pagination information |
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -218,7 +218,7 @@ The `get_waku_v2_store_v1_messages` method retrieves historical messages on spec
 
 | Field | Type | Inclusion | Description |
 | ----: | :---: | :---: |----------- |
-| `pubsubTopic` | `String` | mandatory | The pubsub topic on which a  [`WakuMessage`](#WakuMessage) is published|
+| `pubsubTopic` | `String` | mandatory | The pubsub topic on which a  [`WakuMessage`](#WakuMessage) is published |
 | `contentFilters` | `Array`[[`ContentFilter`](#contentfilter)] | mandatory | Array of content filters to query for historical messages |
 | `pagingOptions` | [`PagingOptions`](#PagingOptions) | optional | Pagination information |
 


### PR DESCRIPTION
This is meant to reflect the latest update on the store json rpc api as in https://github.com/status-im/nim-waku/pull/514 in the specs. 
Adds pubsub topic field to the history query and the query examples.

Closes https://github.com/status-im/nim-waku/issues/485