### PR TITLE
16/WAKU2-RPC Move to `draft`

### DIFF
--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -5,7 +5,6 @@ bookMenuLevels: 1
 
 - Raw
   - [15/WAKU2-BRIDGE]({{< relref "/docs/rfcs/15/README.md" >}})
-  - [16/WAKU2-RPC]({{< relref "/docs/rfcs/16/README.md" >}})
   - [17/WAKU2-RLNRELAY]({{< relref "/docs/rfcs/17/README.md" >}})
   - [18/WAKU2-SWAP]({{< relref "/docs/rfcs/18/README.md" >}})
   - [19/WAKU2-LIGHTPUSH]({{< relref "/docs/rfcs/19/README.md" >}})
@@ -20,6 +19,7 @@ bookMenuLevels: 1
   - [12/WAKU2-FILTER]({{< relref "/docs/rfcs/12/README.md" >}})
   - [13/WAKU2-STORE]({{< relref "/docs/rfcs/13/README.md" >}})
   - [14/WAKU2-MESSAGE]({{< relref "/docs/rfcs/14/README.md" >}})
+  - [16/WAKU2-RPC]({{< relref "/docs/rfcs/16/README.md" >}})
 - Stable
   - [2/MVDS]({{< relref "/docs/rfcs/2/README.md" >}})
   - [6/WAKU1]({{< relref "/docs/rfcs/6/README.md" >}})


### PR DESCRIPTION
Fix: `16/WAKU2-RPC` is already in `draft` status but still indexed under `Raw`.