### PR TITLE
Add GH action to automatically add issues to the project board

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,15 @@
+name: Add new issues Vac PM Board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-new-issue-to-new-column:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.6.0
+        with:
+          project: Vac PM Board
+          column: New
+          repo-token: ${{ secrets.GH_ACTION_PROJECT_MGMT }}


### PR DESCRIPTION
@oskarth We need to add a secret and I don't have the rights to do so one this repo.

Doc: https://github.com/alex-page/github-project-automation-plus
Or just click on [this](https://github.com/settings/tokens/new?scopes=repo,write:org&description=GH_ACTION_PROJECT_MGMT) to be taken through the token generation (and then add it as a secret for rfc repo).