### PR TITLE
23/topic recommendations

### DIFF
--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -128,7 +128,7 @@ This creates a direct mapping between the two protocols.
 For example:
 
 ```
-/waku/v1/0x007f80ff/rlp
+/waku/1/0x007f80ff/rlp
 ```
 
 # Copyright

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -82,11 +82,10 @@ This means you are likely to have to run your own full nodes which may make your
 
 The other type of topic that exists in Waku v2 is content topics.
 This is used for content based filtering.
-This is specified in the [14/WAKU2-MESSAGE spec](/spec/14).
+See [14/WAKU2-MESSAGE spec](/spec/14) for where this is specified.
 Note that this doesn't impact routing of messages between relaying nodes,
 but it does impact how request/reply protocols such as 
-[12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/)
-[13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) are used.
+[12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/) and [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) are used.
 
 This is especially useful for nodes that have limited bandwidth,
 and only want to pull down messages that match this filter.
@@ -110,7 +109,7 @@ All messages are sent to all other nodes.
 This means that we are implicitly using the same PubSub topic that would be something like:
 
 ```
-/waku/1/default-waku/rlp/
+/waku/1/default-waku/rlp
 ```
 
 Topics in Waku v1 correspond to Content Topics in Waku v2.

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -7,16 +7,17 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This document outlines recommended usage of topics in Waku v2. In [10/WAKU2 spec](/spec/10) there are two types of topics:
+This document outlines recommended usage of topics in Waku v2.
+In [10/WAKU2 spec](/spec/10) there are two types of topics:
 
-- Pubsub topics, used for routing
+- PubSub topics, used for routing
 - Content topics, used for content-based filtering
 
-## Pubsub topics
+## PubSub topics
 
-Pubsub topics are used for routing of mesages, see [11/WAKU2-RELAY](/spec/11) spec for more details of how this routing works.
+PubSub topics are used for routing of messages, see [11/WAKU2-RELAY](/spec/11) spec for more details of how this routing works.
 
-As written in [10/WAKU2 spec](/spec/10) there is a default Pubsub topic:
+As written in [10/WAKU2 spec](/spec/10) there is a default PubSub topic:
 
 `/waku/2/default-waku/proto`
 
@@ -27,7 +28,7 @@ This indicates that
 3) `default-waku` indicates that it is the default topic for exchanging WakuMessages
 4) that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf as determined by WakuMessage
 
-### Pubsub topic format
+### PubSub topic format
 
 PubSub topics SHOULD follow the following structure:
 
@@ -46,8 +47,13 @@ However, in certain situations other topics MAY be used.
 Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
 See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
 
-If you use another PubSub topic, be aware that metadata protection might be weakened,
-and other nodes in the network might not subscribe or store messages for your given Pubsub topic.
+If you use another PubSub topic, be aware that:
+
+- Metadata protection might be weakened
+- Nodes subscribing to other topics might not be connected to the rest of the network
+- Other nodes in the network might not subscribe and relay on your given PubSub topic
+- Store nodes might not store messages for your given PubSub topic
+
 This means you are likely to have to run your own full nodes which may make your application less robust.
 
 Below we outline some scenarios where this might apply.
@@ -85,7 +91,7 @@ Not yet implemented, but would be easy to add with:
 
 ## Content topics
 
-The other type of topic that exists in Waku v2 is content topics.
+The other type of topic that exists in Waku v2 is a content topic.
 This is used for content based filtering.
 See [14/WAKU2-MESSAGE spec](/spec/14) for where this is specified.
 Note that this doesn't impact routing of messages between relaying nodes,
@@ -93,7 +99,7 @@ but it does impact how request/reply protocols such as
 [12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/) and [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) are used.
 
 This is especially useful for nodes that have limited bandwidth,
-and only want to pull down messages that match this filter.
+and only want to pull down messages that match this given content topic.
 
 Since all messages are relayed using the relay protocol regardless of content topic,
 you MAY use any content topic you wish without impacting how messages are relayed.

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -113,9 +113,7 @@ The format for content topics is as follows:
 The name of a content topic is application-specific.
 As an example, here's the content topic used for an upcoming testnet:
 
-`/waku/2/huilong/proto`
-
-<!-- TODO Consider if this should be /toychat/2/huilong/proto -->
+`/toychat/2/huilong/proto`
 
 ## Using content topics for your application
 

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -25,7 +25,7 @@ This indicates that
 1) It relates to the Waku problem domain
 2) version is 2
 3) name indicates what is being exchanged, which in this case is WakuMessages over a single topic and
-4) that the data in PubSub field is protobuf (unlike Eth2 where it is `ssz_snappy`) as determined by WakuMessage.
+4) that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf as determined by WakuMessage.
 
 ### Pubsub topic format
 
@@ -50,7 +50,7 @@ If you use another PubSub topic, be aware that metadata protection might be weak
 and other nodes in the network might not subscribe or store messages for your given Pubsub topic.
 This means you are likely to have to run your own full nodes which may make your application less robust.
 
-Below we outline some examples where this might apply.
+Below we outline some scenarios where this might apply.
 
 ### Separation of two applications example
 
@@ -95,17 +95,31 @@ but it does impact how request/reply protocols such as
 This is especially useful for nodes that have limited bandwidth,
 and only want to pull down messages that match this filter.
 
-Since all messages are relayed regardless of content topic, you MAY use any content topic you wish without impacting how messages are relayed.
+Since all messages are relayed using the relay protocol regardless of content topic,
+you MAY use any content topic you wish without impacting how messages are relayed.
 
 ### Content topic format
 
-The format of content topics is as follows:
+The format for content topics is as follows:
 
-`/waku/2/ContentTopic/Encoding`
+`/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
 
-The name of ContentTopic is application-specific. As an example, here's the content topic used for an upcoming testnet:
+The name of a content topic is application-specific.
+As an example, here's the content topic used for an upcoming testnet:
 
 `/waku/2/huilong/proto`
+
+<!-- TODO Consider if this should be /toychat/2/huilong/proto -->
+
+## Using content topics for your application
+
+Make sure you have a unique application-name to avoid conflicting issues with other protocols.
+
+If you have different versions of your protocol, this can be specified in the version field.
+
+The name of the content topic is up to your application and depends on the problem domain, how you want to separate content, what the bandwidth and privacy guarantees are, etc.
+
+The encoding field indicates the serialization/encoding scheme for the [WakuMessage payload](/spec/14/#payloads) field.
 
 ## Differences with Waku v1
 
@@ -123,7 +137,7 @@ Topics in Waku v1 correspond to Content Topics in Waku v2.
 
 To bridge Waku v1 and Waku v2 we have a [15/WAKU-BRIDGE](/spec/15).
 For mapping Waku v1 topics to Waku v2 content topics,
-the following structure is used:
+the following structure for the content topic is used:
 
 ```
 /waku/v1/<4bytes-waku-v1-topic>/rlp

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -27,12 +27,23 @@ This indicates that
 3) name indicates what is being exchanged, which in this case is WakuMessages over a single topic and
 4) that the data in PubSub field is protobuf (unlike Eth2 where it is `ssz_snappy`) as determined by WakuMessage.
 
+### Default PubSub topic
+
 The default PubSub topic SHOULD be used for all protocols.
 However, in certain situations other topics MAY be used.
 
+Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
+See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
+
+If you use another PubSub topic, be aware that metadata protection might be weakened,
+and other nodes in the network might not subscribe or store messages for your given Pubsub topic.
+This means you are likely to have to run your own full nodes which may make your application less robust.
+
+Below we outline some examples where this might apply.
+
 ### Pubsub topic format
 
-PubSub topics SHOULD follow the folloing structure:
+PubSub topics SHOULD follow the following structure:
 
 `/waku/2/TopicName/Encoding`
 
@@ -54,7 +65,7 @@ This indicates that they are WakuMessages but for different domains completely.
 
 ### Topic sharding example
 
-Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic. Here's a sketch for what this might look like:
+Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic. Here's an example of what this might look like:
 
 ```
 waku/2/waku-9_shard-0/proto
@@ -69,14 +80,6 @@ This indicates explicitly that the network traffic has been partitioned into 10 
 Not yet implemented, but would be easy to add with:
 
 `/waku/2/default-waku/proto_snappy`
-
-### Why use a single PubSub topic by default?
-
-Using a single PubSub topic ensures a connected network, as well some degree of metadata protection. See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
-
-If you use another PubSub topic, be aware that metadata protection might be weakened,
-and other nodes in the network might not subscribe or store messages for your given Pubsub topic.
-This means you are likely to have to run your own full nodes which may make your application less robust.
 
 ## Content topics
 

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -24,8 +24,8 @@ This indicates that
 
 1) It relates to the Waku problem domain
 2) version is 2
-3) name indicates what is being exchanged, which in this case is WakuMessages over a single topic and
-4) that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf as determined by WakuMessage.
+3) `default-waku` indicates that it is the default topic for exchanging WakuMessages
+4) that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf as determined by WakuMessage
 
 ### Pubsub topic format
 
@@ -58,8 +58,8 @@ Let's say we have two different topics that are both experience heavy traffic bu
 This can be segregated into:
 
 ```
-/waku/2/waku-status/proto
-/waku/2/waku-walletconnect/proto
+/waku/2/status/proto
+/waku/2/walletconnect/proto
 ```
 
 This indicates that they are WakuMessages but for different domains completely.

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -1,0 +1,22 @@
+---
+slug: 23
+title: 23/WAKU2-TOPICS
+name: Waku v2 Topic Usage Recommendations
+status: raw
+editor: Oskar Thoren <oskar@status.im>
+contributors:
+---
+
+This document outlines recommended usage of topics in Waku v2.
+
+- The type of topics that exist in Waku v2
+  - PubSub, content topic
+  - Purpose of them
+  - Difference with Waku v1
+- General format of pubsub and content topic
+- Rationale re privacy/bw preservation
+  - Recommend privacy but may use others
+  - Additional considerations
+- Needle in haystack
+- Bridging Waku v1 format
+

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -27,9 +27,20 @@ This indicates that
 3) name indicates what is being exchanged, which in this case is WakuMessages over a single topic and
 4) that the data in PubSub field is protobuf (unlike Eth2 where it is `ssz_snappy`) as determined by WakuMessage.
 
+### Pubsub topic format
+
+PubSub topics SHOULD follow the following structure:
+
+`/waku/2/{topic-name}/{encoding}`
+
+This namespaced structure makes things like compatibility and discoverability and automatic handling of new topics easier.
+For example, if the encoding of the payload is changed, compression is introduced, etc.
+
+For more on this format of PubSub topics, see [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages) where inspiration for this format was taken from.
+
 ### Default PubSub topic
 
-The default PubSub topic SHOULD be used for all protocols.
+Unless there's a good reason, the default PubSub topic SHOULD be used for all protocols.
 However, in certain situations other topics MAY be used.
 
 Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
@@ -41,20 +52,10 @@ This means you are likely to have to run your own full nodes which may make your
 
 Below we outline some examples where this might apply.
 
-### Pubsub topic format
-
-PubSub topics SHOULD follow the following structure:
-
-`/waku/2/TopicName/Encoding`
-
-This namespaced structure makes things like compatibility and discoverability and automatic handling of new topics easier.
-For example, if the encoding of the payload is changed, compression is introduced, etc.
-
-For more on this format of PubSub topics, see [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages) where inspiration for this format was taken from.
-
 ### Separation of two applications example
 
-Let's say we have some M2M topic that is heavy and experience a lot of heavy traffic and a Status Network one. This can be segregated into:
+Let's say we have two different topics that are both experience heavy traffic but are completely separate in terms of problem domain and infrastructure.
+This can be segregated into:
 
 ```
 /waku/2/waku-status/proto
@@ -65,7 +66,8 @@ This indicates that they are WakuMessages but for different domains completely.
 
 ### Topic sharding example
 
-Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic. Here's an example of what this might look like:
+Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic.
+Here's an example of what this might look like:
 
 ```
 waku/2/waku-9_shard-0/proto

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -2,21 +2,155 @@
 slug: 23
 title: 23/WAKU2-TOPICS
 name: Waku v2 Topic Usage Recommendations
-status: raw
+status: draft
 editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This document outlines recommended usage of topics in Waku v2.
+This document outlines recommended usage of topics in Waku v2. In [10/WAKU2 spec](/spec/10) there are two types of topics:
 
-- The type of topics that exist in Waku v2
-  - PubSub, content topic
-  - Purpose of them
-  - Difference with Waku v1
-- General format of pubsub and content topic
-- Rationale re privacy/bw preservation
-  - Recommend privacy but may use others
-  - Additional considerations
-- Needle in haystack
-- Bridging Waku v1 format
+- Pubsub topics, used for routing
+- Content topics, used for content-based filtering
 
+## Pubsub topics
+
+Pubsub topics are used for routing of mesages, see [11/WAKU2-RELAY](/spec/11) spec for more details of how this routing works.
+
+As written in [10/WAKU2 spec](/spec/10) there is a default Pubsub topic:
+
+`/waku/2/default-waku/proto`
+
+This indicates that
+
+1) It relates to the Waku problem domain
+2) version is 2
+3) name indicates what is being exchanged, which in this case is WakuMessages over a single topic and
+4) that the data in PubSub field is protobuf (unlike Eth2 where it is `ssz_snappy`) as determined by WakuMessage.
+
+The default PubSub topic SHOULD be used for all protocols.
+However, in certain situations other topics MAY be used.
+
+### Pubsub topic format
+
+PubSub topics SHOULD follow the folloing structure:
+
+`/waku/2/TopicName/Encoding`
+
+This namespaced structure makes things like compatibility and discoverability and automatic handling of new topics easier.
+For example, if the encoding of the payload is changed, compression is introduced, etc.
+
+For more on this format of PubSub topics, see [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages) where inspiration for this format was taken from.
+
+### Separation of two applications example
+
+Let's say we have some M2M topic that is heavy and experience a lot of heavy traffic and a Status Network one. This can be segregated into:
+
+```
+/waku/2/waku-status/proto
+/waku/2/waku-walletconnect/proto
+```
+
+This indicates that they are WakuMessages but for different domains completely.
+
+### Topic sharding example
+
+Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic. Here's a sketch for what this might look like:
+
+```
+waku/2/waku-9_shard-0/proto
+...
+waku/2/waku-9_shard-9/proto
+```
+
+This indicates explicitly that the network traffic has been partitioned into 10 buckets.
+
+### Compression example
+
+Not yet implemented, but would be easy to add with:
+
+`/waku/2/default-waku/proto_snappy`
+
+### Why use a single PubSub topic by default?
+
+Using a single PubSub topic ensures a connected network, as well some degree of metadata protection. See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
+
+If you use another PubSub topic, be aware that metadata protection might be weakened,
+and other nodes in the network might not subscribe or store messages for your given Pubsub topic.
+This means you are likely to have to run your own full nodes which may make your application less robust.
+
+## Content topics
+
+The other type of topic that exists in Waku v2 is content topics.
+This is used for content based filtering.
+This is specified in the [14/WAKU2-MESSAGE spec](/spec/14).
+Note that this doesn't impact routing of messages between relaying nodes,
+but it does impact how request/reply protocols such as 
+[12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/)
+[13/WAKU2-STORE](https://rfc.vac.dev/spec/13/) are used.
+
+This is especially useful for nodes that have limited bandwidth,
+and only want to pull down messages that match this filter.
+
+Since all messages are relayed regardless of content topic, you MAY use any content topic you wish without impacting how messages are relayed.
+
+### Content topic format
+
+The format of content topics is as follows:
+
+`/waku/2/ContentTopic/Encoding`
+
+The name of ContentTopic is application-specific. As an example, here's the content topic used for an upcoming testnet:
+
+`/waku/2/huilong/proto`
+
+## Differences with Waku v1
+
+In [6/WAKU1](/spec/6) there is no actual routing.
+All messages are sent to all other nodes.
+This means that we are implicitly using the same PubSub topic that would be something like:
+
+```
+/waku/1/default-waku/rlp/
+```
+
+Topics in Waku v1 correspond to Content Topics in Waku v2.
+
+### Bridging Waku v1 and Waku v2
+
+To bridge Waku v1 and Waku v2 we have a [15/WAKU-BRIDGE](/spec/15).
+For mapping Waku v1 topics to Waku v2 content topics,
+the following structure is used:
+
+```
+/waku/v1/<4bytes-waku-v1-topic>/rlp
+```
+
+This creates a direct mapping between the two protocols.
+For example:
+
+```
+/waku/v1/0x007f80ff/rlp
+```
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+1. [10/WAKU2 spec](/spec/10)
+
+2. [11/WAKU2-RELAY](/spec/11)
+
+3. [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages)
+
+4. [14/WAKU2-MESSAGE spec](/spec/14)
+
+5. [12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/)
+
+6. [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/)
+
+7. [6/WAKU1](/spec/6)
+
+8. [15/WAKU-BRIDGE](/spec/15)


### PR DESCRIPTION
This PR introduces recommendations for topic usage in Waku v2:

- Pubsub topics
- Content topics
- Rationale, format and example
- Differences with Waku v1

Since this will be one of the main things clients of Waku v2 will control, feedback at this stage would be much appreciated. This way we can make sure the design accommodates various deployments, meets requirements from applications, etc.