### PR TITLE
Change protocol Identifier for Swap Protocol to beta1

### DIFF
--- a/content/docs/rfcs/18/README.md
+++ b/content/docs/rfcs/18/README.md
@@ -4,11 +4,12 @@ title: 18/WAKU2-SWAP
 name: Waku SWAP Accounting
 status: raw
 editor: Oskar Thorén <oskar@status.im>
+contributor: Ebube Ud <ebube@status.im>
 ---
 
 This specification outlines how we do accounting and settlement based on the provision and usage of resources, most immediately bandwidth usage and/or storing and retrieving of Waku message. This enables nodes to cooperate and efficiently share resources, and in the case of unequal nodes to settle the difference through a relaxed payment mechanism in the form of sending cheques.
 
-**Protocol identifier***: `/vac/waku/swap/2.0.0-alpha2`
+**Protocol identifier***: `/vac/waku/swap/2.0.0-beta1`
 
 # Motivation
 


### PR DESCRIPTION
The protocol identifier for the swap protocol was updated to beta1. 
This references the Issue on [#573](https://github.com/status-im/nim-waku/issues/573)
