### PR TITLE
Add waku-core tag

### DIFF
--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -3,7 +3,7 @@ slug: 11
 title: 11/WAKU2-RELAY
 name: Waku v2 Relay
 status: draft
-category: core
+tags: waku-core
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Oskar Thorén <oskar@status.im>

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -3,7 +3,7 @@ slug: 12
 title: 12/WAKU2-FILTER
 name: Waku v2 Filter
 status: draft
-category: core
+tags: waku-core
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>

--- a/content/docs/rfcs/15/README.md
+++ b/content/docs/rfcs/15/README.md
@@ -3,7 +3,7 @@ slug: 15
 title: 15/WAKU-BRIDGE
 name: Waku Bridge
 status: draft
-category: core
+tags: waku-core
 editor: Hanno Cornelius <hanno@status.im>
 ---
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -3,7 +3,7 @@ slug: 16
 title: 16/WAKU2-RPC
 name: Waku v2 RPC API
 status: draft
-category: core
+tags: waku-core
 editor: Hanno Cornelius <hanno@status.im>
 ---
 


### PR DESCRIPTION
This partially addresses https://github.com/vacp2p/rfc/issues/368

It adds `waku-core` tag for specs 11, 12, 15, 16

Note that this is the same as the tag merged in https://github.com/vacp2p/rfc/commit/d7b9af24d4fe2db1f1a2cd45dd283c03392ea131, but different from the suggested `waku-core-protocol` in the description for https://github.com/vacp2p/rfc/issues/368 - @D4nte, I do not have a strong preference between `waku-core` and `waku-core-protocol`, but at this stage it seems easier to just update the description?