### PR TITLE
11/WAKU2-RELAY: Move relay specification to `stable`

### DIFF
--- a/content/docs/rfcs/10/README.md
+++ b/content/docs/rfcs/10/README.md
@@ -54,7 +54,7 @@ interaction domains:
 
 The current [protocol identifiers](https://docs.libp2p.io/concepts/protocols/) are:
 
-1. `/vac/waku/relay/2.0.0-beta2`
+1. `/vac/waku/relay/2.0.0`
 2. `/vac/waku/store/2.0.0-beta3`
 3. `/vac/waku/filter/2.0.0-beta1`
 4. `/vac/waku/swap/2.0.0-beta1`
@@ -81,7 +81,7 @@ This length integer is encoded as a [protobuf varint](https://developers.google.
 
 ## Gossip domain
 
-**Protocol identifier**: `/vac/waku/relay/2.0.0-beta2`
+**Protocol identifier**: `/vac/waku/relay/2.0.0`
 
 See [11/WAKU2-RELAY](/spec/11) spec for more details.
 

--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -2,7 +2,7 @@
 slug: 11
 title: 11/WAKU2-RELAY
 name: Waku v2 Relay
-status: draft
+status: stable
 tags: waku-core
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
@@ -14,7 +14,7 @@ contributors:
 Its current implementation is a minor extension of the [libp2p GossipSub protocol](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md) and prescribes gossip-based dissemination.
 As such the scope is limited to defining a separate [`protocol id`](https://github.com/libp2p/specs/blob/master/connections/README.md#protocol-negotiation) for `11/WAKU2-RELAY`, establishing privacy and security requirements, and defining how the underlying GossipSub is to be interpreted and implemented within the Waku and cryptoeconomic domain.
 
-**Protocol identifier**: `/vac/waku/relay/2.0.0-beta2`
+**Protocol identifier**: `/vac/waku/relay/2.0.0`
 
 # Security Requirements
 

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -14,7 +14,6 @@ bookMenuLevels: 1
   - [3/REMOTE-LOG]({{< relref "/docs/rfcs/3/README.md" >}})
   - [4/MVDS-META]({{< relref "/docs/rfcs/4/README.md" >}})
   - [10/WAKU2]({{< relref "/docs/rfcs/10/README.md" >}})
-  - [11/WAKU2-RELAY]({{< relref "/docs/rfcs/11/README.md" >}})
   - [12/WAKU2-FILTER]({{< relref "/docs/rfcs/12/README.md" >}})
   - [13/WAKU2-STORE]({{< relref "/docs/rfcs/13/README.md" >}})
   - [14/WAKU2-MESSAGE]({{< relref "/docs/rfcs/14/README.md" >}})
@@ -30,6 +29,7 @@ bookMenuLevels: 1
   - [7/WAKU-DATA]({{< relref "/docs/rfcs/7/README.md" >}})
   - [8/WAKU-MAIL]({{< relref "/docs/rfcs/8/README.md" >}})
   - [9/WAKU-RPC]({{< relref "/docs/rfcs/9/README.md" >}})
+  - [11/WAKU2-RELAY]({{< relref "/docs/rfcs/11/README.md" >}})
 - Deprecated
   - [5/WAKU0]({{< relref "/docs/rfcs/5/README.md" >}})
 - Retired


### PR DESCRIPTION
This bumps `11/WAKU2-RELAY` to `stable`, partially addressing https://github.com/vacp2p/rfc/issues/406

The stable protocol ID is `/vac/waku/relay/2.0.0`