### PR TITLE
26/WAKU-PAYLOAD

### DIFF
--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -38,9 +38,9 @@ ECIES is using the following cryptosystem:
 
 ## Specification
 
-For 6/WAKU1, the `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the `waku envelope`.
+For 6/WAKU1, the `data` field is used in the `waku envelope`, and the field MUST contain the encrypted payload.
 
-For 10/WAKU2, the `payload` field is used within the `WakuMessage` and MUST contain the encrypted payload of `Waku Message`.
+For 10/WAKU2, the `payload` field is used in `WakuMessage` and MUST contain the encrypted payload.
 
 The fields that are concatenated and encrypted as part of the field are:
  - flags

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -11,6 +11,8 @@ This specification describes how encryption, decryption and signing works in [6/
 
 It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
 
+Large sections of the spec originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption).
+
 ## Cryptographic primitives
 
 - AES-256-GCM

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -48,7 +48,7 @@ For 10/WAKU2, the `payload` field is used in `WakuMessage` and MUST contain the 
 
 The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
  - flags
- - auxiliary field
+ - payload length
  - payload
  - padding
  - signature

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -1,0 +1,62 @@
+---
+slug: 26
+title: 26/WAKU-PAYLOAD
+name: Waku Message Payload Encryption
+status: draft
+editor: Oskar Thoren <oskar@status.im>
+contributors:
+---
+
+This specification describes the encryption, decryption and signing of the content in the [data field used in Waku](/spec/6/#abnf-specification).
+
+## Specification
+
+The `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the envelope.
+
+The fields that are concatenated and encrypted as part of the `data` field are:
+ - flags
+ - auxiliary field
+ - payload
+ - padding
+ - signature
+ 
+In case of symmetric encryption, a `salt`  (a.k.a. AES Nonce, 12 bytes) field MUST be appended. 
+
+### ABNF
+
+Using [Augmented Backus-Naur form (ABNF)](https://tools.ietf.org/html/rfc5234) we have the following format:
+
+```abnf
+; 1 byte; first two bits contain the size of auxiliary field, 
+; third bit indicates whether the signature is present.
+flags           = 1OCTET
+
+; contains the size of payload.
+auxiliary-field = 4*OCTET
+
+; byte array of arbitrary size (may be zero)
+payload         = *OCTET
+
+; byte array of arbitrary size (may be zero).
+padding         = *OCTET
+
+; 65 bytes, if present.
+signature       = 65OCTET
+
+; 2 bytes, if present (in case of symmetric encryption).
+salt            = 2OCTET
+
+data        = flags auxiliary-field payload padding [signature] [salt]
+```
+
+### Signature
+
+Those unable to decrypt the envelope data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialized as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` MUST be big-endian encoded, fixed-width 256-bit unsigned. `V` MUST be an 8-bit big-endian encoded, non-normalized and should be either 27 or 28.
+
+### Padding
+
+The padding field is used to align data size, since data size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -29,7 +29,7 @@ ECIES is using the following cryptosystem:
 
 Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
 For more details, see the section below.
-In case of a signature being provided, the public key is recoverable from by utilizing the `v` parameter.
+In case of a signature being provided, the public key is recoverable by utilizing the `v` parameter.
 
 Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -113,7 +113,7 @@ The cryptosystem used is:
 - `MAC(k, m)`: HMAC using the SHA-256 hash function.
 - `AES(k, iv, m)`: the AES-128 encryption function in CTR mode.
 
-Special notation used: `X || Y` denotes concatenation of X and Y.
+Special notation used: `X || Y` denotes concatenation of `X` and `Y`.
 
 Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -7,12 +7,12 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This specification describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
-It provides confidentiality, authenticity, and integrity over an asynchronous network.
+This specification describes how Waku provides provides confidentiality, authenticity, and integrity.
+Specifically, it describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
 
-It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
+This specification effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
 
-Large sections of the spec originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) with some modifications.
+Large sections of the specification originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) with some modifications.
 
 ## Design requirements
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -8,10 +8,20 @@ contributors:
 ---
 
 This specification describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
+It provides confidentiality, authenticity, and integrity over an asynchronous network.
 
 It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
 
-Large sections of the spec originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption).
+Large sections of the spec originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) with some modifications.
+
+## Design requirements
+
+- *Confidentiality*: The adversary should not be able to learn what data is being exchanged between two Waku nodes.
+- *Authenticity*: The adversary should not be able to cause either of two Waku endpoint to accept data from any third party as though it came from the other endpoint.
+- *Integrity*: The adversary should not be able to cause either of two Waku endpoints to accept data that has been tampered with.
+
+Notable, *forward secrecy* is not provided for at this layer.
+If this property is desired, a more fully featured secure communication protocol can be used on top, such as [Status 5/SECURE-TRANSPORT](https://specs.status.im/spec/5).
 
 ## Cryptographic primitives
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -9,6 +9,12 @@ contributors:
 
 This specification describes the encryption, decryption and signing of the content in the [data field used in Waku](/spec/6/#abnf-specification).
 
+## Payload Encryption
+
+Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme with SECP-256k1 public key.
+
+Symmetric encryption uses AES GCM algorithm with random 96-bit nonce.
+
 ## Specification
 
 The `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the envelope.

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -100,7 +100,7 @@ The signature is serialized as the concatenation of the `r`, `s` and `v` paramet
 
 The padding field is used to align data size, since data size alone might reveal important metainformation.
 Padding can be arbitrary size.
-However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be multiple of 256 bytes.
+However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be a multiple of 256 bytes.
 
 ### ECIES encryption
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -46,9 +46,9 @@ For 6/WAKU1, the `data` field is used in the `waku envelope`, and the field MAY 
 
 For 10/WAKU2, the `payload` field is used in `WakuMessage` and MAY contain the encrypted payload.
 
-The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
+The fields that are concatenated and encrypted as part of the `data` (Waku v1) / `payload` (Waku v2) field are:
  - flags
- - payload length
+ - payload-length
  - payload
  - padding
  - signature
@@ -75,6 +75,9 @@ padding         = *OCTET
 signature       = 65OCTET
 
 data            = flags payload-length payload padding [signature]
+
+; This field is called payload in Waku v2
+payload         = data
 ```
 
 ### Signature

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -7,7 +7,7 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This specification describes how Waku provides provides confidentiality, authenticity, and integrity, as well as some form unlinkability.
+This specification describes how Waku provides confidentiality, authenticity, and integrity, as well as some form of unlinkability.
 Specifically, it describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
 
 This specification effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -128,16 +128,60 @@ Alice sends the encrypted message `R || iv || c || d` where `c = AES(kE, iv , m)
 For Bob to decrypt the message `R || iv || c || d`, he derives the shared secret `S = Px` where `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
 Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv || c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
 
+### Decoding a message
+
+In order to decode a message, a node SHOULD try to apply both symmetric and asymmetric decryption operations.
+
 ## References
 
-- Authenticated encryption: https://en.wikipedia.org/wiki/Authenticated_encryption
-
-- RLPx Transport Protocol (ECIES encryption): https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
-
-- EIP-627: Whisper specification: https://eips.ethereum.org/EIPS/eip-627
-
-- Status 5/SECURE-TRANSPORT: https://specs.status.im/spec/5
+1. [6/WAKU1](/spec/6)
+2. [10/WAKU2](/spec/10)
+3. [14/WAKU-MESSAGE version 1](/spec/14/#version1)
+4. [7/WAKU-DATA](/spec/7)
+5. [6/WAKU1 Payload encryption](/spec/6/#payload-encryption)
+6. [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627)
+7. [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption)
+8. [Status 5/SECURE-TRANSPORT](https://specs.status.im/spec/5)
+9. [Augmented Backus-Naur form (ABNF)](https://tools.ietf.org/html/rfc5234)
+10. [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption)
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Scratch
+
+- Refer to different for WakuMessage spec
+- Create separate issue for issue with v parameter
+- How to encrypt encode/decode try both
+- Because sig is inside only meant for can see...
+- Between one or more peers...
+- Confirm Kim "However, it is recommended that the size of Data Field (excluding the IV) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.""
+
+### Issue with v parameter
+
+
+This should be 0,1, but due to Bitcoin standard it is 27, 28. Later on, this has moved in Ethereum to:
+
+V = CHAIN_ID * 2 + 35:
+
+See:
+- https://eips.ethereum.org/EIPS/eip-155
+- https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739
+- https://coders-errand.com/ecrecover-signature-verification-ethereum/
+
+### Where is ephemeral key in ECIES?
+
+https://github.com/ethereum/go-ethereum/blob/master/crypto/ecies/ecies.go#L232
+
+Looks like: receiver pub key Rb + symencrypt + messagetag
+
+https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
+
+### Does RLPx known crypto issue impacts us?
+
+Here: https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
+
+https://crypto.stackexchange.com/questions/63047/ethereum-rlpx-protocol-for-inter-node-communication-flaws-in-the-encryption
+
+--

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -106,7 +106,7 @@ The signature is serialized as the concatenation of the `r`, `s` and `v` paramet
 
 The padding field is used to align data size, since data size alone might reveal important metainformation.
 Padding can be arbitrary size.
-However, it is recommended that the size of Data Field (excluding the IV) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
 
 ### ECIES encryption
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -48,8 +48,8 @@ For 10/WAKU2, the `payload` field is used in `WakuMessage` and MAY contain the e
 
 The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
  - flags
- - payload/data length
- - payload/data
+ - payload length
+ - payload
  - padding
  - signature
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -106,7 +106,7 @@ The signature is serialized as the concatenation of the `r`, `s` and `v` paramet
 
 The padding field is used to align data size, since data size alone might reveal important metainformation.
 Padding can be arbitrary size.
-However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be multiple of 256 bytes.
 
 ### ECIES encryption
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -7,7 +7,7 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This specification describes how Waku provides provides confidentiality, authenticity, and integrity.
+This specification describes how Waku provides provides confidentiality, authenticity, and integrity, as well as some form unlinkability.
 Specifically, it describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
 
 This specification effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
@@ -22,6 +22,8 @@ Large sections of the specification originate from [EIP-627: Whisper spec](https
 
 Notable, *forward secrecy* is not provided for at this layer.
 If this property is desired, a more fully featured secure communication protocol can be used on top, such as [Status 5/SECURE-TRANSPORT](https://specs.status.im/spec/5).
+
+Because (a) only participants who are able to decrypt a message can see its signature (b) padding is used, it also provides some form of *unlinkability*.
 
 ## Cryptographic primitives
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -128,6 +128,7 @@ Bob verifies the authenticity of the message by checking whether `d == MAC(sha25
 ### Decoding a message
 
 In order to decode a message, a node SHOULD try to apply both symmetric and asymmetric decryption operations.
+This is because the type of encryption is not included in the message.
 
 ## References
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -84,7 +84,8 @@ For more details, see the section below on ECIES encryption.
 
 ### Symmetric encryption
 
-Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag and a 12 byte IV (nonce).
+Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption). 
+The output of encryption is of the form (`ciphertext`, `tag`, `iv`) where `ciphertext` is the encrypted message, `tag` is a 16 byte message authentication tag and `iv` is a 12 byte initialization vector  (nonce). 
 The message authentication `tag` and initialization vector `iv` field MUST be appended to the resulting `ciphertext`, in that order.
 Note that previous specifications and some implementations might refer to `iv` as `nonce` or `salt`.
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -82,11 +82,13 @@ payload         = data
 
 ### Signature
 
-Those unable to decrypt the envelope data are also unable to access the signature.
+Those unable to decrypt the payload/data are also unable to access the signature.
 The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity.
 The signature is serialized as the concatenation of the `r`, `s` and `v` parameters of the SECP-256k1 ECDSA signature, in that order.
 `r` and `s` MUST be big-endian encoded, fixed-width 256-bit unsigned.
 `v` MUST be an 8-bit big-endian encoded, non-normalized and should be either 27 or 28.
+
+See [Ethereum "Yellow paper": Appendix F Signing transactions](https://ethereum.github.io/yellowpaper/paper.pdf) for more information on signature generation, parameters and public key recovery.
 
 ### Encryption
 
@@ -145,7 +147,8 @@ This is because the type of encryption is not included in the message.
 7. [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption)
 8. [Status 5/SECURE-TRANSPORT](https://specs.status.im/spec/5)
 9. [Augmented Backus-Naur form (ABNF)](https://tools.ietf.org/html/rfc5234)
-10. [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption)
+10. [Ethereum "Yellow paper": Appendix F Signing transactions](https://ethereum.github.io/yellowpaper/paper.pdf)
+11. [Authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption)
 
 ## Copyright
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -74,12 +74,6 @@ padding         = *OCTET
 ; 65 bytes, if present.
 signature       = 65OCTET
 
-; 12 bytes, if present (in case of symmetric encryption).
-iv              = 12OCTET
-
-; 16 bytes, if present (in case of symmetric encryption).
-tag             = 16OCTET
-
 data            = flags payload-length payload padding [signature]
 ```
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -18,13 +18,42 @@ It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encry
 - ECSDA
 - KECCAK-256
 
+ECIES is using the following cryptosystem:
+- Curve: secp256k1
+- KDF: NIST SP 800-56 Concatenation Key Derivation Function
+- MAC: HMAC with SHA-256
+- AES: AES-128-CTR
+
+
 ## Payload encryption
 
 Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
+For more details, see the section below.
 In case of a signature being provided, the public key is recoverable from by utilizing the `v` parameter.
 
 Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
 
+## ECIES Encryption
+
+This section originates from the [RLPx Transport Protocol spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) spec with minor modifications.
+
+The cryptosystem used is:
+
+- The elliptic curve secp256k1 with generator `G`.
+- `KDF(k, len)`: the NIST SP 800-56 Concatenation Key Derivation Function
+- `MAC(k, m)`: HMAC using the SHA-256 hash function.
+- `AES(k, iv, m)`: the AES-128 encryption function in CTR mode.
+
+Notiation used in the following section: `X || Y` denotes concatenation of X and Y.
+
+Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
+
+To encrypt the message `m`, Alice generates a random number `r` and corresponding elliptic curve public key `R = r * G` and computes the shared secret `S = Px` where `(Px, Py) = r * KB`.
+She derives key material for encryption and authentication as `kE || kM = KDF(S, 32)` as well as a random initialization vector `iv`.
+Alice sends the encrypted message `R || iv || c || d` where `c = AES(kE, iv , m)` and `d = MAC(sha256(kM), iv || c)` to Bob.
+
+For Bob to decrypt the message `R || iv || c || d`, he derives the shared secret `S = Px` where `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
+Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv || c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
 
 ## Specification
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -46,7 +46,7 @@ For 6/WAKU1, the `data` field is used in the `waku envelope`, and the field MUST
 
 For 10/WAKU2, the `payload` field is used in `WakuMessage` and MUST contain the encrypted payload.
 
-The fields that are concatenated and encrypted as part of the field are:
+The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
  - flags
  - auxiliary field
  - payload

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -121,6 +121,12 @@ Bob verifies the authenticity of the message by checking whether `d == MAC(sha25
 
 - Authenticated encryption: https://en.wikipedia.org/wiki/Authenticated_encryption
 
+- RLPx Transport Protocol (ECIES encryption): https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
+
+- EIP-627: Whisper specification: https://eips.ethereum.org/EIPS/eip-627
+
+- Status 5/SECURE-TRANSPORT: https://specs.status.im/spec/5
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -7,13 +7,9 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This specification describes how encryption, decryption and signing works in
-[6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version
-1](/spec/14/#version1).
+This specification describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).
 
-It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload
-encryption](/spec/6/#payload-encryption) but written in a way that is agnostic
-and self-contained for Waku v1 and Waku v2.
+It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.
 
 ## Cryptographic primitives
 
@@ -27,7 +23,8 @@ and self-contained for Waku v1 and Waku v2.
 Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
 In case of a signature being provided, the public key is recoverable from by utilizing the `v` parameter.
 
-Symmetric encryption uses AES-256-GCM for authenticated encryption [TODO], with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
+Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
+
 
 ## Specification
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -115,7 +115,7 @@ The cryptosystem used is:
 
 Special notation used: `X || Y` denotes concatenation of `X` and `Y`.
 
-Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
+Alice wants to send an encrypted message that can be decrypted by Bob's static private key `kB`. Alice knows about Bobs static public key `KB`.
 
 To encrypt the message `m`, Alice generates a random number `r` and corresponding elliptic curve public key `R = r * G` and computes the shared secret `S = Px` where `(Px, Py) = r * KB`.
 She derives key material for encryption and authentication as `kE || kM = KDF(S, 32)` as well as a random initialization vector `iv`.

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -29,7 +29,7 @@ It also provides some form of *unlinkability* since:
 
 ## Cryptographic primitives
 
-- AES-256-GCM
+- AES-256-GCM (for symmetric encryption)
 - ECIES
 - ECDSA
 - KECCAK-256

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -77,18 +77,6 @@ signature       = 65OCTET
 data            = flags payload-length payload padding [signature]
 ```
 
-### Asymmetric encryption
-
-Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
-For more details, see the section below on ECIES encryption.
-
-### Symmetric encryption
-
-Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption). 
-The output of encryption is of the form (`ciphertext`, `tag`, `iv`) where `ciphertext` is the encrypted message, `tag` is a 16 byte message authentication tag and `iv` is a 12 byte initialization vector  (nonce). 
-The message authentication `tag` and initialization vector `iv` field MUST be appended to the resulting `ciphertext`, in that order.
-Note that previous specifications and some implementations might refer to `iv` as `nonce` or `salt`.
-
 ### Signature
 
 Those unable to decrypt the envelope data are also unable to access the signature.
@@ -97,13 +85,20 @@ The signature is serialized as the concatenation of the `r`, `s` and `v` paramet
 `r` and `s` MUST be big-endian encoded, fixed-width 256-bit unsigned.
 `v` MUST be an 8-bit big-endian encoded, non-normalized and should be either 27 or 28.
 
-### Padding
+### Encryption
 
-The padding field is used to align data size, since data size alone might reveal important metainformation.
-Padding can be arbitrary size.
-However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be a multiple of 256 bytes.
+#### Symmetric
 
-### ECIES encryption
+Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption). 
+The output of encryption is of the form (`ciphertext`, `tag`, `iv`) where `ciphertext` is the encrypted message, `tag` is a 16 byte message authentication tag and `iv` is a 12 byte initialization vector  (nonce). 
+The message authentication `tag` and initialization vector `iv` field MUST be appended to the resulting `ciphertext`, in that order.
+Note that previous specifications and some implementations might refer to `iv` as `nonce` or `salt`.
+
+#### Asymmetric
+
+Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
+
+#### ECIES
 
 This section originates from the [RLPx Transport Protocol spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) spec with minor modifications.
 
@@ -124,6 +119,12 @@ Alice sends the encrypted message `R || iv || c || d` where `c = AES(kE, iv , m)
 
 For Bob to decrypt the message `R || iv || c || d`, he derives the shared secret `S = Px` where `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
 Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv || c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
+
+### Padding
+
+The padding field is used to align data size, since data size alone might reveal important metainformation.
+Padding can be arbitrary size.
+However, it is recommended that the size of Data Field (excluding the IV and tag) before encryption (i.e. plain text) SHOULD be a multiple of 256 bytes.
 
 ### Decoding a message
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -42,9 +42,9 @@ ECIES is using the following cryptosystem:
 
 ## Specification
 
-For 6/WAKU1, the `data` field is used in the `waku envelope`, and the field MUST contain the encrypted payload.
+For 6/WAKU1, the `data` field is used in the `waku envelope`, and the field MAY contain the encrypted payload.
 
-For 10/WAKU2, the `payload` field is used in `WakuMessage` and MUST contain the encrypted payload.
+For 10/WAKU2, the `payload` field is used in `WakuMessage` and MAY contain the encrypted payload.
 
 The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
  - flags

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -31,7 +31,7 @@ It also provides some form of *unlinkability* since:
 
 - AES-256-GCM
 - ECIES
-- ECSDA
+- ECDSA
 - KECCAK-256
 
 ECIES is using the following cryptosystem:

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -36,7 +36,7 @@ It also provides some form of *unlinkability* since:
 
 ECIES is using the following cryptosystem:
 - Curve: secp256k1
-- KDF: NIST SP 800-56 Concatenation Key Derivation Function
+- KDF: NIST SP 800-56 Concatenation Key Derivation Function, with SHA-256 option
 - MAC: HMAC with SHA-256
 - AES: AES-128-CTR
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -26,7 +26,6 @@ ECIES is using the following cryptosystem:
 - MAC: HMAC with SHA-256
 - AES: AES-128-CTR
 
-
 ## Payload encryption
 
 Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
@@ -42,11 +41,11 @@ This section originates from the [RLPx Transport Protocol spec](https://github.c
 The cryptosystem used is:
 
 - The elliptic curve secp256k1 with generator `G`.
-- `KDF(k, len)`: the NIST SP 800-56 Concatenation Key Derivation Function
+- `KDF(k, len)`: the NIST SP 800-56 Concatenation Key Derivation Function.
 - `MAC(k, m)`: HMAC using the SHA-256 hash function.
 - `AES(k, iv, m)`: the AES-128 encryption function in CTR mode.
 
-Notiation used in the following section: `X || Y` denotes concatenation of X and Y.
+Special notation used: `X || Y` denotes concatenation of X and Y.
 
 Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -58,7 +58,7 @@ The fields that are concatenated and encrypted as part of the `data`/`payload` f
 Using [Augmented Backus-Naur form (ABNF)](https://tools.ietf.org/html/rfc5234) we have the following format:
 
 ```abnf
-; 1 byte; first two bits contain the size of auxiliary field, 
+; 1 byte; first two bits contain the size of payload-length field,
 ; third bit indicates whether the signature is present.
 flags           = 1OCTET
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -36,36 +36,6 @@ ECIES is using the following cryptosystem:
 - MAC: HMAC with SHA-256
 - AES: AES-128-CTR
 
-## Payload encryption
-
-Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
-For more details, see the section below.
-In case of a signature being provided, the public key is recoverable by utilizing the `v` parameter.
-
-Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
-
-## ECIES Encryption
-
-This section originates from the [RLPx Transport Protocol spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) spec with minor modifications.
-
-The cryptosystem used is:
-
-- The elliptic curve secp256k1 with generator `G`.
-- `KDF(k, len)`: the NIST SP 800-56 Concatenation Key Derivation Function.
-- `MAC(k, m)`: HMAC using the SHA-256 hash function.
-- `AES(k, iv, m)`: the AES-128 encryption function in CTR mode.
-
-Special notation used: `X || Y` denotes concatenation of X and Y.
-
-Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
-
-To encrypt the message `m`, Alice generates a random number `r` and corresponding elliptic curve public key `R = r * G` and computes the shared secret `S = Px` where `(Px, Py) = r * KB`.
-She derives key material for encryption and authentication as `kE || kM = KDF(S, 32)` as well as a random initialization vector `iv`.
-Alice sends the encrypted message `R || iv || c || d` where `c = AES(kE, iv , m)` and `d = MAC(sha256(kM), iv || c)` to Bob.
-
-For Bob to decrypt the message `R || iv || c || d`, he derives the shared secret `S = Px` where `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
-Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv || c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
-
 ## Specification
 
 For 6/WAKU1, the `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the `waku envelope`.
@@ -115,6 +85,37 @@ Those unable to decrypt the envelope data are also unable to access the signatur
 ### Padding
 
 The padding field is used to align data size, since data size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+
+
+### Payload encryption
+
+Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
+For more details, see the section below.
+In case of a signature being provided, the public key is recoverable by utilizing the `v` parameter.
+
+Symmetric encryption uses AES-256-GCM for [authenticated encryption](https://en.wikipedia.org/wiki/Authenticated_encryption), with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
+
+### ECIES Encryption
+
+This section originates from the [RLPx Transport Protocol spec](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) spec with minor modifications.
+
+The cryptosystem used is:
+
+- The elliptic curve secp256k1 with generator `G`.
+- `KDF(k, len)`: the NIST SP 800-56 Concatenation Key Derivation Function.
+- `MAC(k, m)`: HMAC using the SHA-256 hash function.
+- `AES(k, iv, m)`: the AES-128 encryption function in CTR mode.
+
+Special notation used: `X || Y` denotes concatenation of X and Y.
+
+Alice wants to send an encrypted message that can be decrypted by Bobs static private key `kB`. Alice knows about Bobs static public key `KB`.
+
+To encrypt the message `m`, Alice generates a random number `r` and corresponding elliptic curve public key `R = r * G` and computes the shared secret `S = Px` where `(Px, Py) = r * KB`.
+She derives key material for encryption and authentication as `kE || kM = KDF(S, 32)` as well as a random initialization vector `iv`.
+Alice sends the encrypted message `R || iv || c || d` where `c = AES(kE, iv , m)` and `d = MAC(sha256(kM), iv || c)` to Bob.
+
+For Bob to decrypt the message `R || iv || c || d`, he derives the shared secret `S = Px` where `(Px, Py) = kB * R` as well as the encryption and authentication keys `kE || kM = KDF(S, 32)`.
+Bob verifies the authenticity of the message by checking whether `d == MAC(sha256(kM), iv || c)` then obtains the plaintext as `m = AES(kE, iv || c)`.
 
 ## References
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -7,13 +7,27 @@ editor: Oskar Thoren <oskar@status.im>
 contributors:
 ---
 
-This specification describes the encryption, decryption and signing of the content in the [data field used in Waku](/spec/6/#abnf-specification).
+This specification describes how encryption, decryption and signing works in
+[6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version
+1](/spec/14/#version1).
 
-## Payload Encryption
+It effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload
+encryption](/spec/6/#payload-encryption) but written in a way that is agnostic
+and self-contained for Waku v1 and Waku v2.
 
-Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme with SECP-256k1 public key.
+## Cryptographic primitives
 
-Symmetric encryption uses AES GCM algorithm with random 96-bit nonce.
+- AES-256-GCM
+- ECIES
+- ECSDA
+- KECCAK-256
+
+## Payload encryption
+
+Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Scheme (ECIES) with SECP-256k1 public key.
+In case of a signature being provided, the public key is recoverable from by utilizing the `v` parameter.
+
+Symmetric encryption uses AES-256-GCM for authenticated encryption [TODO], with a 16 byte authentication tag 16 and a 12 byte IV (nonce).
 
 ## Specification
 
@@ -62,6 +76,10 @@ Those unable to decrypt the envelope data are also unable to access the signatur
 ### Padding
 
 The padding field is used to align data size, since data size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.
+
+## References
+
+- Authenticated encryption: https://en.wikipedia.org/wiki/Authenticated_encryption
 
 ## Copyright
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -48,8 +48,8 @@ For 10/WAKU2, the `payload` field is used in `WakuMessage` and MAY contain the e
 
 The fields that are concatenated and encrypted as part of the `data`/`payload` field are:
  - flags
- - payload length
- - payload
+ - payload/data length
+ - payload/data
  - padding
  - signature
 

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -31,9 +31,11 @@ Symmetric encryption uses AES-256-GCM for authenticated encryption [TODO], with 
 
 ## Specification
 
-The `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the envelope.
+For 6/WAKU1, the `data` field is used within the `waku envelope`, the field MUST contain the encrypted payload of the `waku envelope`.
 
-The fields that are concatenated and encrypted as part of the `data` field are:
+For 10/WAKU2, the `payload` field is used within the `WakuMessage` and MUST contain the encrypted payload of `Waku Message`.
+
+The fields that are concatenated and encrypted as part of the field are:
  - flags
  - auxiliary field
  - payload

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -80,7 +80,7 @@ iv              = 12OCTET
 ; 16 bytes, if present (in case of symmetric encryption).
 tag             = 16OCTET
 
-data            = flags auxiliary-field payload padding [signature]
+data            = flags payload-length payload padding [signature]
 ```
 
 ### Asymmetric encryption

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -16,14 +16,16 @@ Large sections of the specification originate from [EIP-627: Whisper spec](https
 
 ## Design requirements
 
-- *Confidentiality*: The adversary should not be able to learn what data is being exchanged between two Waku nodes.
-- *Authenticity*: The adversary should not be able to cause either of two Waku endpoint to accept data from any third party as though it came from the other endpoint.
-- *Integrity*: The adversary should not be able to cause either of two Waku endpoints to accept data that has been tampered with.
+- *Confidentiality*: The adversary should not be able to learn what data is being sent from one Waku node to one or several other Waku nodes.
+- *Authenticity*: The adversary should not be able to cause Waku endpoint to accept data from any third party as though it came from the other endpoint.
+- *Integrity*: The adversary should not be able to cause a Waku endpoint to accept data that has been tampered with.
 
 Notable, *forward secrecy* is not provided for at this layer.
 If this property is desired, a more fully featured secure communication protocol can be used on top, such as [Status 5/SECURE-TRANSPORT](https://specs.status.im/spec/5).
 
-Because (a) only participants who are able to decrypt a message can see its signature (b) padding is used, it also provides some form of *unlinkability*.
+It also provides some form of *unlinkability* since:
+- only participants who are able to decrypt a message can see its signature
+- payload are padded to a fixed length
 
 ## Cryptographic primitives
 
@@ -148,40 +150,3 @@ In order to decode a message, a node SHOULD try to apply both symmetric and asym
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-
-## Scratch
-
-- Refer to different for WakuMessage spec
-- Create separate issue for issue with v parameter
-- How to encrypt encode/decode try both
-- Because sig is inside only meant for can see...
-- Between one or more peers...
-- Confirm Kim "However, it is recommended that the size of Data Field (excluding the IV) before encryption (i.e. plain text) SHOULD be factor of 256 bytes.""
-
-### Issue with v parameter
-
-
-This should be 0,1, but due to Bitcoin standard it is 27, 28. Later on, this has moved in Ethereum to:
-
-V = CHAIN_ID * 2 + 35:
-
-See:
-- https://eips.ethereum.org/EIPS/eip-155
-- https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739
-- https://coders-errand.com/ecrecover-signature-verification-ethereum/
-
-### Where is ephemeral key in ECIES?
-
-https://github.com/ethereum/go-ethereum/blob/master/crypto/ecies/ecies.go#L232
-
-Looks like: receiver pub key Rb + symencrypt + messagetag
-
-https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
-
-### Does RLPx known crypto issue impacts us?
-
-Here: https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption
-
-https://crypto.stackexchange.com/questions/63047/ethereum-rlpx-protocol-for-inter-node-communication-flaws-in-the-encryption
-
---

--- a/content/docs/rfcs/26/README.md
+++ b/content/docs/rfcs/26/README.md
@@ -72,8 +72,8 @@ padding         = *OCTET
 ; 65 bytes, if present.
 signature       = 65OCTET
 
-; 2 bytes, if present (in case of symmetric encryption).
-salt            = 2OCTET
+; 12 bytes, if present (in case of symmetric encryption).
+salt            = 12OCTET
 
 data        = flags auxiliary-field payload padding [signature] [salt]
 ```

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -23,6 +23,7 @@ bookMenuLevels: 1
   - [19/WAKU2-LIGHTPUSH]({{< relref "/docs/rfcs/19/README.md" >}})
   - [22/TOY-CHAT]({{< relref "/docs/rfcs/22/README.md" >}})
   - [23/WAKU2-TOPICS]({{< relref "/docs/rfcs/23/README.md" >}})
+  - [26/WAKU2-PAYLOAD]({{< relref "/docs/rfcs/26/README.md" >}})
 - Stable
   - [2/MVDS]({{< relref "/docs/rfcs/2/README.md" >}})
   - [6/WAKU1]({{< relref "/docs/rfcs/6/README.md" >}})


### PR DESCRIPTION
Addresses https://github.com/vacp2p/rfc/issues/412

This specification describes how Waku provides provides confidentiality, authenticity, and integrity, as well as some form unlinkability.
Specifically, it describes how encryption, decryption and signing works in [6/WAKU1](/spec/6) and in [10/WAKU2](/spec/10) with [14/WAKU-MESSAGE version 1](/spec/14/#version1).

This specification effectively replaces [7/WAKU-DATA](/spec/7) as well as [6/WAKU1 Payload encryption](/spec/6/#payload-encryption) but written in a way that is agnostic and self-contained for Waku v1 and Waku v2.

Large sections of the specification originate from [EIP-627: Whisper spec](https://eips.ethereum.org/EIPS/eip-627) as well from [RLPx Transport Protocol spec (ECIES encryption)](https://github.com/ethereum/devp2p/blob/master/rlpx.md#ecies-encryption) with some modifications.

---

I based this largely on (a) existing specs (b) looking at how nim-eth implements stuff, and a bit at the go-ethereum implementation. I've probably missed something, so a critical eye would be useful here!

Note that this is about documenting existing behavior, not improving it. Improving it based on clear issues would be something for later, but thoughts on this would be welcome. See this issue: https://github.com/vacp2p/rfc/issues/414