### PR TITLE
27/WAKU2-PEERS: Waku v2 Client Peer Management Recommendations

### DIFF
--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -37,12 +37,12 @@ It is RECOMMENDED that a Waku v2 client tracks at least the following informatio
 ## Peer connectivity
 
 A Waku v2 client SHOULD track _at least_ the following connectivity states for each of its peers:
- - **NOT CONNECTED**: The peer has been discovered or configured on this client,
+ - **`NotConnected`**: The peer has been discovered or configured on this client,
  but no attempt has yet been made to connect to this peer.
  This is the default state for a new peer.
- - **CANNOT CONNECT**: The client attempted to connect to this peer, but failed.
- - **CAN CONNECT**: The client was recently connected to this peer and disconnected gracefully.
- - **CONNECTED**: The client is actively connected to this peer.
+ - **`CannotConnect`**: The client attempted to connect to this peer, but failed.
+ - **`CanConnect`**: The client was recently connected to this peer and disconnected gracefully.
+ - **`Connected`**: The client is actively connected to this peer.
 
 This list does not preclude clients from tracking more advanced connectivity metadata,
 such as a peer's blacklist status (see (`18/WAKU2-SWAP`)[https://rfc.vac.dev/spec/18/]).

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -2,7 +2,7 @@
 slug: 27
 title: 27/WAKU2-PEERS
 name: Waku v2 Client Peer Management Recommendations
-status: raw
+status: draft
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
 ---
@@ -31,8 +31,8 @@ It is RECOMMENDED that a Waku v2 client tracks at least the following informatio
 | _Public key_  | The public key for this peer. This is related to the libp2p [`Peer ID`](https://docs.libp2p.io/concepts/peer-id/). |
 | _Addresses_ | Known transport layer [`multiaddrs`](https://docs.libp2p.io/concepts/addressing/) for this peer. |
 | _Protocols_ | The libp2p [`protocol IDs`](https://docs.libp2p.io/concepts/protocols/#protocol-ids) supported by this peer. This can be used to track the client's connectivity to peers supporting different Waku v2 protocols, e.g. [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/) or [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/). |
-| _Connectivity_ | Tracks the peer's current connectedness state. See [**Peer connectivity**](#Peer-connectivity) below. |
-| _Disconnect time_ | The timestamp at which this peer last disconnected. This becomes important when managing [peer reconnections](#Reconnecting-peers) |
+| _Connectivity_ | Tracks the peer's current connectedness state. See [**Peer connectivity**](#peer-connectivity) below. |
+| _Disconnect time_ | The timestamp at which this peer last disconnected. This becomes important when managing [peer reconnections](#reconnecting-peers) |
 
 ## Peer connectivity
 
@@ -55,16 +55,16 @@ Peer persistence MAY be used to resume peer connections after a client restart.
 
 # Peer management
 
-Waku v2 clients will have different requirements when it comes to managing the peers tracked in the [**peer store**](#Peer-store).
+Waku v2 clients will have different requirements when it comes to managing the peers tracked in the [**peer store**](#peer-store).
 It is RECOMMENDED that clients support:
-- [automatic reconnection](#Reconnecting-peers) to peers under certain conditions
-- [connection keep-alive](#Connection-keep-alive)
+- [automatic reconnection](#reconnecting-peers) to peers under certain conditions
+- [connection keep-alive](#connection-keep-alive)
 
 ## Reconnecting peers
 
-A Waku v2 client MAY choose to reconnect to previously connected, and managed, peers under certain conditions.
+A Waku v2 client MAY choose to reconnect to previously connected, managed peers under certain conditions.
 Such conditions include, but are not limited to:
-- Reconnecting to all `relay`-capable peers after a client restart. This will require [persistent peer storage](#Persistence).
+- Reconnecting to all `relay`-capable peers after a client restart. This will require [persistent peer storage](#persistence).
 
 If a client chooses to automatically reconnect to previous peers,
 it MUST respect the [backing off period](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange) specified for GossipSub v1.1 before attempting to reconnect.

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -68,7 +68,7 @@ Such conditions include, but are not limited to:
 
 If a client chooses to automatically reconnect to previous peers,
 it MUST respect the [backing off period](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange) specified for GossipSub v1.1 before attempting to reconnect.
-This requires keeping track of the [last time each peer was disconnected](#Tracked-peer-metadata).
+This requires keeping track of the [last time each peer was disconnected](#tracked-peer-metadata).
 
 ## Connection keep-alive
 

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -1,0 +1,98 @@
+---
+slug: 27
+title: 27/WAKU2-PEERS
+name: Waku v2 Client Peer Management Recommendations
+status: raw
+editor: Hanno Cornelius <hanno@status.im>
+contributors:
+---
+
+`27/WAKU2-PEERS` describes a recommended minimal set of peer storage and peer management features to be implemented by Waku v2 clients.
+
+In this context, peer _storage_ refers to a client's ability to keep track of discovered or statically-configured peers and their metadata.
+It also deals with matters of peer _persistence_,
+or the ability to store peer data on disk to resume state after a client restart.
+
+Peer _management_ is a closely related concept and refers to the set of actions a client MAY choose to perform based on its knowledge of its connected peers,
+e.g. triggering reconnects/disconnects, keeping certain connections alive, etc.
+
+# Peer store
+
+The peer store SHOULD be an in-memory data structure where information about discovered or configured peers are stored.
+It SHOULD be considered the central authority for peer-related information in a Waku v2 client.
+Clients MAY choose to persist this store on-disk.
+
+## Tracked peer metadata
+
+It is RECOMMENDED that a Waku v2 client tracks at least the following information about each of its peers in a peer store:
+
+| Metadata | Description  |
+| --- | --- |
+| _Public key_  | The public key for this peer. This is related to the libp2p [`Peer ID`](https://docs.libp2p.io/concepts/peer-id/). |
+| _Addresses_ | Known transport layer [`multiaddrs`](https://docs.libp2p.io/concepts/addressing/) for this peer. |
+| _Protocols_ | The libp2p [`protocol IDs`](https://docs.libp2p.io/concepts/protocols/#protocol-ids) supported by this peer. This can be used to track the client's connectivity to peers supporting different Waku v2 protocols, e.g. [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/) or [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/). |
+| _Connectivity_ | Tracks the peer's current connectedness state. See [**Peer connectivity**](#Peer-connectivity) below. |
+| _Disconnect time_ | The timestamp at which this peer last disconnected. This becomes important when managing [peer reconnections](#Reconnecting-peers) |
+
+## Peer connectivity
+
+A Waku v2 client SHOULD track _at least_ the following connectivity states for each of its peers:
+ - **NOT CONNECTED**: The peer has been discovered or configured on this client,
+ but no attempt has yet been made to connect to this peer.
+ This is the default state for a new peer.
+ - **CANNOT CONNECT**: The client attempted to connect to this peer, but failed.
+ - **CAN CONNECT**: The client was recently connected to this peer and disconnected gracefully.
+ - **CONNECTED**: The client is actively connected to this peer.
+
+This list does not preclude clients from tracking more advanced connectivity metadata,
+such as a peer's blacklist status (see (`18/WAKU2-SWAP`)[https://rfc.vac.dev/spec/18/]).
+
+## Persistence
+
+A Waku v2 client MAY choose to persist peers across restarts,
+using any offline storage technology, such as an on-disk database.
+Peer persistence COULD be used to resume peer connections after a client restart.
+
+# Peer management
+
+Waku v2 clients will have different requirements when it comes to managing the peers tracked in the [**peer store**](#Peer-store).
+It is RECOMMENDED that clients support:
+- [automatic reconnection](#Reconnecting-peers) to peers under certain conditions
+- [connection keep-alive](#Connection-keep-alive)
+
+## Reconnecting peers
+
+A Waku v2 client MAY choose to reconnect to previously connected, and managed, peers under certain conditions.
+Such conditions include, but are not limited to:
+- Reconnecting to all `relay`-capable peers after a client restart. This will require [persistent peer storage](#Persistence).
+
+If a client chooses to automatically reconnect to previous peers,
+it MUST respect the [backing off period](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange) specified for GossipSub v1.1 before attempting to reconnect.
+This requires keeping track of the [last time each peer was disconnected](#Tracked-peer-metadata).
+
+## Connection keep-alive
+
+A Waku v2 client MAY choose to implement a keep-alive mechanism to certain peers.
+If a client chooses to implement keep-alive on a connection,
+it SHOULD do so by sending periodic [libp2p pings](https://docs.libp2p.io/concepts/protocols/#ping) as per `10/WAKU2` [client recommendations](https://rfc.vac.dev/spec/10/#recommendations-for-clients).
+The recommended period between pings SHOULD be _at most_ 50% of the shortest idle connection timeout for the specific client and transport.
+For example, idle TCP connections often times out after 10 to 15 minutes.
+
+> **Implementation note:** the `nim-waku` client currently implements a keep-alive mechanism every `5 minutes`,
+in response to a TCP connection timeout of `10 minutes`.
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+1. [`10/WAKU2` client recommendations](https://rfc.vac.dev/spec/10/#recommendations-for-clients)
+1. [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/)
+1. [`13/WAKU2-STORE`](https://rfc.vac.dev/spec/13/)
+1. [`libp2p` peer ID](https://docs.libp2p.io/concepts/peer-id/)
+1. [`libp2p` ping protocol](https://docs.libp2p.io/concepts/protocols/#ping)
+1. [`libp2p` protocol IDs](https://docs.libp2p.io/concepts/protocols/#protocol-ids)
+1. [`multiaddrs`](https://docs.libp2p.io/concepts/addressing/)
+

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -51,7 +51,7 @@ such as a peer's blacklist status (see (`18/WAKU2-SWAP`)[https://rfc.vac.dev/spe
 
 A Waku v2 client MAY choose to persist peers across restarts,
 using any offline storage technology, such as an on-disk database.
-Peer persistence COULD be used to resume peer connections after a client restart.
+Peer persistence MAY be used to resume peer connections after a client restart.
 
 # Peer management
 
@@ -95,4 +95,3 @@ Copyright and related rights waived via
 1. [`libp2p` ping protocol](https://docs.libp2p.io/concepts/protocols/#ping)
 1. [`libp2p` protocol IDs](https://docs.libp2p.io/concepts/protocols/#protocol-ids)
 1. [`multiaddrs`](https://docs.libp2p.io/concepts/addressing/)
-

--- a/content/docs/rfcs/27/README.md
+++ b/content/docs/rfcs/27/README.md
@@ -19,7 +19,7 @@ e.g. triggering reconnects/disconnects, keeping certain connections alive, etc.
 # Peer store
 
 The peer store SHOULD be an in-memory data structure where information about discovered or configured peers are stored.
-It SHOULD be considered the central authority for peer-related information in a Waku v2 client.
+It SHOULD be considered the main source of truth for peer-related information in a Waku v2 client.
 Clients MAY choose to persist this store on-disk.
 
 ## Tracked peer metadata

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -23,6 +23,7 @@ bookMenuLevels: 1
   - [19/WAKU2-LIGHTPUSH]({{< relref "/docs/rfcs/19/README.md" >}})
   - [22/TOY-CHAT]({{< relref "/docs/rfcs/22/README.md" >}})
   - [23/WAKU2-TOPICS]({{< relref "/docs/rfcs/23/README.md" >}})
+  - [27/WAKU2-PEERS]({{< relref "/docs/rfcs/27/README.md" >}})
 - Stable
   - [2/MVDS]({{< relref "/docs/rfcs/2/README.md" >}})
   - [6/WAKU1]({{< relref "/docs/rfcs/6/README.md" >}})


### PR DESCRIPTION
This PR closes https://github.com/vacp2p/rfc/issues/415

It documents a (minimal) set of peer storage and peer management recommendations for Waku v2 clients.
The `nim-waku` implementation is used as baseline. The purpose of this recommendation spec is to facilitate development of new Waku v2 clients. It is expected that different Waku v2 clients will have different peer management requirements.

Peer management, in general, is a far wider concept than what is covered in this recommendation.
See [this ongoing effort](https://github.com/status-im/nim-libp2p/issues/537) by the `nim-libp2p` team for reference.