### PR TITLE
14-WAKU2-MESSAGE: Adds security consideration about the timestamp field

### DIFF
--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -84,7 +84,7 @@ The application layer decides on how the `payload` of a `WakuMessage` shall be e
 
 ## Reliability of WakuMessage timestamp 
 The `timestamp` field in `WakuMessage` is set by its sender. 
-Without a proper `timestamp` verification and validation, this field should not be relied upon for critical operations like message ordering.
+Without a proper `timestamp` verification and validation, this field is prone to exploit and should not be relied upon for critical operations like message ordering.
 This is because an attacker can set the `timestamp` arbitrarily and e.g., bump it to a high value so that it always be the *latest* in a chat.
 Applications relying on the `WakuMessage`'s `timestamp` are recommended to utilize a proper timestamp validation method.
 For example, Status specs deal with message ordering against adversarial message timestamps as described in [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -78,9 +78,9 @@ The previous `data` field corresponds to the `payload` field.
 # Security Consideration
 
 ## Confidentiality, integrity, and authenticity 
-Data confidentiality, integrity, and authenticity is an application layer concern. 
-The application layer decides on how the `payload` of a `WakuMessage` shall be encrypted or signed to meet the privacy needs.
-[WAKU2-PAYLOAD](/specs/26) presents the set of supported encryption and signature schemes in WAKU2.
+It is up to the application layer as to what level confidentiality, integrity and authenticity of the `payload` of `WakuMessage` matters. 
+Accordingly, the application layer shall utilize the encryption and signature schemes supported in WAKU2 to meet the application-specific privacy needs.
+The set of supported schemes in WAKU2 is presented in [WAKU2-PAYLOAD](/specs/26).
 
 ## Reliability of the WakuMessage timestamp
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -86,7 +86,7 @@ The application layer decides on how the `payload` of a `WakuMessage` shall be e
 The `timestamp` field in `WakuMessage` is set by its sender. 
 Without a proper `timestamp` verification and validation, this field should not be relied upon for critical operations like message ordering.
 This is because an attacker can set the `timestamp` arbitrarily and e.g., bump it to a high value so that it always be the *latest* in a chat.
-Applications relying on the `WakuMessage`'s `timestamp` are recommended to utilize a timestamp validation method that fits their context.
+Applications relying on the `WakuMessage`'s `timestamp` are recommended to utilize a proper timestamp validation method.
 For example, Status specs deal with message ordering against adversarial message timestamps as described in [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).
 
 # Copyright

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -78,9 +78,9 @@ The previous `data` field corresponds to the `payload` field.
 # Security Consideration
 
 ## Confidentiality, integrity, and authenticity 
-In Waku, the data confidentiality, integrity, and authenticity is an application layer concern. 
+Data confidentiality, integrity, and authenticity is an application layer concern. 
 The application layer decides on how the `payload` of a `WakuMessage` shall be encrypted or signed to meet the privacy needs.
-[WAKU2-PAYLOAD](/content/docs/rfcs/26/README.md) presents the set of available tools in this regard.
+[WAKU2-PAYLOAD](/content/docs/rfcs/26/README.md) presents the set of supported encryption and signature schemes in WAKU2.
 
 ## Reliability of WakuMessage timestamp 
 The `timestamp` field in `WakuMessage` is set by its sender. 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -80,7 +80,7 @@ The previous `data` field corresponds to the `payload` field.
 ## Confidentiality, integrity, and authenticity 
 Data confidentiality, integrity, and authenticity is an application layer concern. 
 The application layer decides on how the `payload` of a `WakuMessage` shall be encrypted or signed to meet the privacy needs.
-[WAKU2-PAYLOAD](/content/docs/rfcs/26/README.md) presents the set of supported encryption and signature schemes in WAKU2.
+[WAKU2-PAYLOAD](/specs/26) presents the set of supported encryption and signature schemes in WAKU2.
 
 ## Reliability of the WakuMessage timestamp
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -77,8 +77,17 @@ The previous `data` field corresponds to the `payload` field.
 
 # Security Consideration
 
-In Waku, the confidentiality, integrity, and authenticity of the data must be addressed at the `WakuMessage` level.
-That is, the `payload` shall be encrypted or signed properly to meet the application-specific privacy needs.
+## Confidentiality, integrity, and authenticity 
+In Waku, the data confidentiality, integrity, and authenticity is an application layer concern. 
+The application layer decides on how the `payload` of a `WakuMessage` shall be encrypted or signed to meet the privacy needs.
+[WAKU2-PAYLOAD](/content/docs/rfcs/26/README.md) presents the set of available tools in this regard.
+
+## Reliability of WakuMessage timestamp 
+The `timestamp` field in `WakuMessage` is set by its sender. 
+Without a proper `timestamp` verification and validation, this field should not be relied upon for critical operations like message ordering.
+This is because an attacker can set the `timestamp` arbitrarily and e.g., bump it to a high value so that it always be the *latest* in a chat.
+Applications relying on the `WakuMessage`'s `timestamp` are recommended to utilize a timestamp validation method that fits their context.
+For example, Status specs deal with message ordering against adversarial message timestamps as described in [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).
 
 # Copyright
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -82,12 +82,15 @@ Data confidentiality, integrity, and authenticity is an application layer concer
 The application layer decides on how the `payload` of a `WakuMessage` shall be encrypted or signed to meet the privacy needs.
 [WAKU2-PAYLOAD](/content/docs/rfcs/26/README.md) presents the set of supported encryption and signature schemes in WAKU2.
 
-## Reliability of WakuMessage timestamp 
-The `timestamp` field in `WakuMessage` is set by its sender. 
-Without a proper `timestamp` verification and validation, this field is prone to exploit and should not be relied upon for critical operations like message ordering.
-This is because an attacker can set the `timestamp` arbitrarily and e.g., bump it to a high value so that it always be the *latest* in a chat.
-Applications relying on the `WakuMessage`'s `timestamp` are recommended to utilize a proper timestamp validation method.
-For example, Status specs deal with message ordering against adversarial message timestamps as described in [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).
+## Reliability of the WakuMessage timestamp
+
+The `timestamp` field in `WakuMessage` is set by the sender.
+Because `timestamp` isn't independently verified, this field is prone to exploit and misuse.
+It should not solely be relied upon for operations such as message ordering.
+
+For example, a malicious node can arbitrarily set the  `timestamp` of a `WakuMessage` to a high value so that it always shows up as the most recent message in a chat application.
+Applications using the `WakuMessage`'s `timestamp` field are recommended to use additional methods for more robust message ordering.
+An example of how to deal with message ordering against adversarial message timestamps can be found in the Status protocol, see [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).
 
 # Copyright
 


### PR DESCRIPTION
This is to add an explainer about the security issues related to sender-generated timestamps in waku messages.
For more context please see https://github.com/vacp2p/rfc/issues/440
I have also used the PR to revise the discussion about the encryption and signature usage in the waku message and add a link to the recent rfc-26.