### PR TITLE
Clarification about mailserver trust requirement

### DIFF
--- a/content/docs/rfcs/6/README.md
+++ b/content/docs/rfcs/6/README.md
@@ -126,7 +126,7 @@ ttl = 4OCTET
 
 ; 4 bytes of arbitrary data
 topic = 4OCTET
-
+x
 ; byte array of arbitrary size
 ; (contains encrypted payload)
 data = *OCTET
@@ -472,13 +472,13 @@ Waku currently lacks incentives to run nodes, which means node operators are mor
 
 #### Light node privacy:
 
-The main privacy concern with a light node is that it has to reveal its topic interests (in addition to its IP and ID) to its directed peers. This is because when a light node publishes an envelope, its directed peers will know that the light node owns that envelope (as light nodes do not relay other envelopes). Therefore, the directed peers of a light node can make assumptions about what envelopes (topics) the light node is interested in.
+The main privacy concern with a light node is that it has to reveal its topic interests (in addition to its IP/ID) to its directed peers. This is because when a light node publishes an envelope, its directed peers will know that the light node owns that envelope (as light nodes do not relay other envelopes). Therefore, the directed peers of a light node can make assumptions about what envelopes (topics) the light node is interested in.
 
 
 #### Mailserver client privacy:
 
 A mailserver client fetches archival envelopes from a mailserver through a direct connection. 
-In this direct connection, the client discloses its IP and ID as well as the topics/ bloom filter it is interested in to the mailserver.
+In this direct connection, the client discloses its IP/ID as well as the topics/ bloom filter it is interested in to the mailserver.
 The collection of such information allows the mailserver to link clients' IP/IDs to their topic interests and build a profile for each client over time.
 As such, the mailserver client has to trust the mailserver with this level of information. 
 

--- a/content/docs/rfcs/6/README.md
+++ b/content/docs/rfcs/6/README.md
@@ -472,7 +472,15 @@ Waku currently lacks incentives to run nodes, which means node operators are mor
 
 #### Light node privacy:
 
-The main privacy concern with light nodes is that directly connected peers will know that an envelope originates from them (as it are the only ones it sends). This means nodes can make assumptions about what envelopes (topics) their peers are interested in.
+The main privacy concern with light nodes is that they have to trust their directly connected peers with regard to their ID, IP and their topic interests. The reason for this trust requirement is that when a light node publishes an envelope, its directed peers will know that the light node owns that envelope (as light nodes do not relay other envelopes). Therefore, the directed peers of a light node can make assumptions about what envelopes (topics) the light node is interested in.
+
+
+#### Mailserver client privacy:
+
+A mailserver client fetches archival envelopes from a mailserver through direct connection. 
+In this direct connection, the client discloses its IP and ID as well as the topics/ bloom filter it is interested in to the mailserver.
+The collection of such information allows the mailserver to link clients IP/IDs to their topic interests and build a profile for each client over the time.
+As such, the mailserver client has to trust the mailserver with this level of information. 
 
 #### Bloom filter privacy:
 

--- a/content/docs/rfcs/6/README.md
+++ b/content/docs/rfcs/6/README.md
@@ -126,7 +126,7 @@ ttl = 4OCTET
 
 ; 4 bytes of arbitrary data
 topic = 4OCTET
-x
+
 ; byte array of arbitrary size
 ; (contains encrypted payload)
 data = *OCTET

--- a/content/docs/rfcs/6/README.md
+++ b/content/docs/rfcs/6/README.md
@@ -472,14 +472,14 @@ Waku currently lacks incentives to run nodes, which means node operators are mor
 
 #### Light node privacy:
 
-The main privacy concern with light nodes is that they have to trust their directly connected peers with regard to their ID, IP and their topic interests. The reason for this trust requirement is that when a light node publishes an envelope, its directed peers will know that the light node owns that envelope (as light nodes do not relay other envelopes). Therefore, the directed peers of a light node can make assumptions about what envelopes (topics) the light node is interested in.
+The main privacy concern with a light node is that it has to reveal its topic interests (in addition to its IP and ID) to its directed peers. This is because when a light node publishes an envelope, its directed peers will know that the light node owns that envelope (as light nodes do not relay other envelopes). Therefore, the directed peers of a light node can make assumptions about what envelopes (topics) the light node is interested in.
 
 
 #### Mailserver client privacy:
 
-A mailserver client fetches archival envelopes from a mailserver through direct connection. 
+A mailserver client fetches archival envelopes from a mailserver through a direct connection. 
 In this direct connection, the client discloses its IP and ID as well as the topics/ bloom filter it is interested in to the mailserver.
-The collection of such information allows the mailserver to link clients IP/IDs to their topic interests and build a profile for each client over the time.
+The collection of such information allows the mailserver to link clients' IP/IDs to their topic interests and build a profile for each client over time.
 As such, the mailserver client has to trust the mailserver with this level of information. 
 
 #### Bloom filter privacy:

--- a/content/docs/rfcs/8/README.md
+++ b/content/docs/rfcs/8/README.md
@@ -96,7 +96,11 @@ A mailserver has to be online to receive envelopes for other nodes, this puts a 
 
 **Mailserver client privacy:**
 
-A mailserver client has to trust a mailserver, which means they can send direct traffic. This reveals what topics / bloom filter a node is interested in, along with its peerID (with IP).
+A mailserver client fetches archival envelopes from a mailserver through a direct connection. 
+In this direct connection, the client discloses its IP/ID as well as the topics/ bloom filter it is interested in to the mailserver.
+The collection of such information allows the mailserver to link clients' IP/IDs to their topic interests and build a profile for each client over time.
+As such, the mailserver client has to trust the mailserver with this level of information.
+A similar concern exists for the light nodes and their direct peers which is discussed in the security considerations of [6/WAKU1](/spec/7).
 
 **Mailserver trusted connection:**
 


### PR DESCRIPTION
Addresses https://github.com/vacp2p/rfc/issues/436
- This PR adds the privacy and trust consideration regarding mailserver clients (the security considerations about other capabilities are already provided, however, the mailserver part is missing).
- It also includes some clarification about the disclosure of a light node's IP/ID to its direct connections.