### PR TITLE
23/WAKU2-TOPICS: bridge content topic changes

### DIFF
--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -145,17 +145,19 @@ For mapping Waku v1 topics to Waku v2 content topics,
 the following structure for the content topic SHOULD be used:
 
 ```
-/waku/1/<4bytes-waku-v1-topic>/rlp
+/waku/1/<4bytes-waku-v1-topic>/rfc7
 ```
 
 The `<4bytes-waku-v1-topic>` SHOULD be the lowercase hex representation of the 4-byte Waku v1 topic.
 A `0x` prefix SHOULD be used.
+`/rfc7` indicates that the bridged content is encoded according to RFC [7/WAKU-DATA](/spec/7).
+See [15/WAKU-BRIDGE](/spec/15) for a description of the bridged fields.
 
 This creates a direct mapping between the two protocols.
 For example:
 
 ```
-/waku/1/0x007f80ff/rlp
+/waku/1/0x007f80ff/rfc7
 ```
 
 # Copyright
@@ -180,3 +182,5 @@ Copyright and related rights waived via
 7. [6/WAKU1](/spec/6)
 
 8. [15/WAKU-BRIDGE](/spec/15)
+
+9. [7/WAKU-DATA](/spec/7)

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -145,19 +145,19 @@ For mapping Waku v1 topics to Waku v2 content topics,
 the following structure for the content topic SHOULD be used:
 
 ```
-/waku/1/<4bytes-waku-v1-topic>/rfc7
+/waku/1/<4bytes-waku-v1-topic>/rfc26
 ```
 
 The `<4bytes-waku-v1-topic>` SHOULD be the lowercase hex representation of the 4-byte Waku v1 topic.
 A `0x` prefix SHOULD be used.
-`/rfc7` indicates that the bridged content is encoded according to RFC [7/WAKU-DATA](/spec/7).
+`/rfc26` indicates that the bridged content is encoded according to RFC [26/WAKU-PAYLOAD](/spec/26).
 See [15/WAKU-BRIDGE](/spec/15) for a description of the bridged fields.
 
 This creates a direct mapping between the two protocols.
 For example:
 
 ```
-/waku/1/0x007f80ff/rfc7
+/waku/1/0x007f80ff/rfc26
 ```
 
 # Copyright
@@ -183,4 +183,4 @@ Copyright and related rights waived via
 
 8. [15/WAKU-BRIDGE](/spec/15)
 
-9. [7/WAKU-DATA](/spec/7)
+9. [26/WAKU-PAYLOAD](/spec/26)


### PR DESCRIPTION
This PR proposes a change to the recommended content topic format for bridging between Waku v1 and Waku v2.

The recommended format for content topics are:
```
/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}
```

Previously the recommended applied format for bridged content topics were:
```
/waku/1/<4bytes-waku-v1-topic>/rlp
```
suggesting that the bridged payloads are `rlp` encoded.

However, the payload is not `rlp` encoded, but byte-encoded according to [RFC 7/WAKU-DATA](https://rfc.vac.dev/spec/7/).

~~The recommended change is therefore~~
```
/waku/1/<4bytes-waku-v1-topic>/rfc7
```
~~to be explicit (and accurate) about the encoding used on bridged content topics.~~

Feel free to comment below if you have any other suggestions/objections.

UPDATE: since [rfc26](https://rfc.vac.dev/spec/26/) replaced rfc7, the updated recommended change is:
```
/waku/1/<4bytes-waku-v1-topic>/rfc26
```

cc @michaelsbradleyjr