### PR TITLE
Adds RateLimitProof protobuf message

### DIFF
--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -150,7 +150,7 @@ Spam protection is partly provided by GossipSub v1.1 through [scoring mechanism]
 At a high level, peers utilize a scoring function to locally score the behavior of their connections and remove peers with a low score.
 `11/WAKU2-RELAY` aims at enabling an advanced spam protection mechanism with economic disincentives by utilizing Rate Limiting Nullifiers.
 In a nutshell, peers must conform to a certain message publishing rate per a system-defined epoch, otherwise, they get financially penalized for exceeding the rate.
-More details on this new technique can be found in [`17/WAKU-RLN`](/spec/17). 
+More details on this new technique can be found in [`17/WAKU-RLN-RELAY`](/spec/17). 
   <!-- TODO havn't checked if all the measures in libp2p GossipSub v1.1 are taken in the nim-libp2p as well, may need to audit the code --> 
 
 - Providing **Unlinkability**, **Integrity** and  **Authenticity** simultaneously:

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -152,22 +152,26 @@ message WakuMessage {
  
 ## RateLimitProof
 
-The `proof` field is an array of 256 bytes and carries the actual zkSNARK proof. 
-Other fields of the `RateLimitProof` message are the [public inputs to the rln circuit](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs).
+The `proof` field is an array of 256 bytes and carries the zkSNARK proof as explained in the [Publishing process](##Publishing).
+The proof asserts that:
+1. The message publisher is the current member of the group i.e., her/his identity commitment key is part of the membership group Merkle tree with the root `merkleRoot`.
+2. `share_x` and `share_y`  are correctly computed.
+3. The `nullifier` is constructed correctly.
 
-The `merkleRoot` indicates the root of the Merkle tree used for the generation of the `proof`. It is an array of 32 bytes.
+Other fields of the `RateLimitProof` message are the public inputs to the rln circuit and used for the generation of the `proof`.
 
-The `epoch` is used for the generation of the `proof`.  It is an array of 32 bytes.
+The `merkleRoot` is an array of 32 bytes which holds the root of membership group Merkle tree at the time of publishing the message.
+
+The `epoch` is an array of 32 bytes that represents the epoch in which the message is published.
 <!-- TODO epoch is going to change to a different type -->
 
 `share_x` and `share_y` are shares of the user's identity key.
-These shares are created using Shamir secret sharing scheme. 
+These shares are created using [Shamir secret sharing scheme](##Publishing). 
 `share_x` is an array of 32 bytes and contains the hash of the `WakuMessage`'s `payload` concatenated with its `contentTopic`. 
 <!-- TODO hash other fields if necessary-->
-`share_y` is also an array of 32 bytes which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
+`share_y` is also an array of 32 bytes which is calculated using [Shamir secret sharing scheme](##Publishing).
 
-The `nullifier` is an [internal nullifier](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers) 
-which allows specifying whether two messages are published by the same publisher during the same `epoch`.
+The `nullifier` is an internal nullifier which allows specifying whether two messages are published by the same publisher during the same `epoch`.
 It is an array of 32 bytes.
 
 <!-- TODO to reflect this change on WakuMessage spec once the PR gets mature -->
@@ -175,3 +179,10 @@ It is an array of 32 bytes.
 # Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+1. [RLN documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view)
+2. [Public inputs to the rln circuit](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs)
+3. [Shamir secret sharing scheme used in RLN](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS)
+4. [RLN internal nullifier](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers)

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -176,13 +176,14 @@ It is an array of 32 bytes.
 
 <!-- TODO to reflect this change on WakuMessage spec once the PR gets mature -->
 
-# Copyright
-
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-
 # References
 
 1. [RLN documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view)
 2. [Public inputs to the rln circuit](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs)
 3. [Shamir secret sharing scheme used in RLN](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS)
 4. [RLN internal nullifier](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers)
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -153,22 +153,22 @@ message WakuMessage {
 ## RateLimitProof
 
 The `proof` field is an array of 256 bytes and carries the actual zkSNARK proof. 
-Other fields of the `RateLimitProof` message are the public inputs to the rln circuit as defined in [rln documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs).
+Other fields of the `RateLimitProof` message are the [public inputs to the rln circuit](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs).
 
-The `merkleRoot` indicates the root of the Merkle tree used for the generation of the `proof`. It is a 32-byte value.
+The `merkleRoot` indicates the root of the Merkle tree used for the generation of the `proof`. It is an array of 32 bytes.
 
-The `epoch` is used for the generation of the `proof`.  It is a 32-byte value. 
+The `epoch` is used for the generation of the `proof`.  It is an array of 32 bytes.
 <!-- TODO epoch is going to change to a different type -->
 
 `share_x` and `share_y` are shares of the user's identity key.
 These shares are created using Shamir's secret sharing scheme. 
-`share_x` is a 32-byte value and contains the hash of the `WakuMessage`'s `payload` concatenated with its `contentTopic`. 
+`share_x` is an array of 32 bytes and contains the hash of the `WakuMessage`'s `payload` concatenated with its `contentTopic`. 
 <!-- TODO hash other fields if necessary-->
-`share_y` is also a 32-byte value which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
+`share_y` is also an array of 32 bytes which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
 
-The `nullifier` corresponds to the internal nullifier described in [rln documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers). 
-It allows specifying whether two messages are published by the same publisher during the same `epoch`.
-It is a 32-byte value.
+The `nullifier` is an [internal nullifier](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers) 
+which allows specifying whether two messages are published by the same publisher during the same `epoch`.
+It is an array of 32 bytes.
 
 <!-- TODO to reflect this change on WakuMessage spec once the PR gets mature -->
 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -130,16 +130,16 @@ syntax = "proto3";
 
 message RateLimitProof {
   bytes proof = 1;
-  bytes merkleRoot = 2;
+  bytes merkle_root = 2;
   bytes epoch = 3;
-  bytes shareX = 4;
-  bytes shareY = 5;
+  bytes share_x = 4;
+  bytes share_y = 5;
   bytes nullifier = 6;
 }
 
 message WakuMessage {
   bytes payload = 1;
-  string content_topic = 2;
+  string contentTopic = 2;
   uint32 version = 3;
   double timestamp = 4;
 + RateLimitProof rate_limit_proof = 21;
@@ -160,11 +160,11 @@ The `merkleRoot` indicates the root of the Merkle tree used for the generation o
 The `epoch` is used for the generation of the `proof`.  It is a 32-byte value. 
 <!-- TODO epoch is going to change to a different type -->
 
-`shareX` and `shareY` are shares of the user's identity key.
+`share_x` and `share_y` are shares of the user's identity key.
 These shares are created using Shamir's secret sharing scheme. 
-`shareX` is a 32-byte value and contains the hash of the `WakuMessage`'s `payload` concatenated with its `content_topic`. 
+`share_x` is a 32-byte value and contains the hash of the `WakuMessage`'s `payload` concatenated with its `contentTopic`. 
 <!-- TODO hash other fields if necessary-->
-`shareY` is also a 32-byte value which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
+`share_y` is also a 32-byte value which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
 
 The `nullifier` corresponds to the internal nullifier described in [rln documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers). 
 It allows specifying whether two messages are published by the same publisher during the same `epoch`.

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -161,7 +161,7 @@ The `epoch` is used for the generation of the `proof`.  It is an array of 32 byt
 <!-- TODO epoch is going to change to a different type -->
 
 `share_x` and `share_y` are shares of the user's identity key.
-These shares are created using Shamir's secret sharing scheme. 
+These shares are created using Shamir secret sharing scheme. 
 `share_x` is an array of 32 bytes and contains the hash of the `WakuMessage`'s `payload` concatenated with its `contentTopic`. 
 <!-- TODO hash other fields if necessary-->
 `share_y` is also an array of 32 bytes which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -1,6 +1,6 @@
 ---
 slug: 17
-title: 17/WAKU-RLN
+title: 17/WAKU-RLN-RELAY
 name: Waku v2 RLN Relay
 status: raw
 tags: waku-core
@@ -128,15 +128,48 @@ Nodes MAY extend the  [14/WAKU2-MESSAGE](/spec/14) with a `proof` field to indic
 
 syntax = "proto3";
 
+message RateLimitProof {
+  bytes proof = 1;
+  bytes merkleRoot = 2;
+  bytes epoch = 3;
+  bytes shareX = 4;
+  bytes shareY = 5;
+  bytes nullifier = 6;
+}
+
 message WakuMessage {
   bytes payload = 1;
-  string contentTopic = 2;
+  string content_topic = 2;
   uint32 version = 3;
   double timestamp = 4;
-+ bytes proof = 21;
++ RateLimitProof rate_limit_proof = 21;
 }
 
 ```
+## WakuMessage
+
+`rate_limit_proof` holds the information required to prove that the message owner has not exceeded the message rate limit.
+ 
+## RateLimitProof
+
+The `proof` field is an array of 256 bytes and carries the actual zkSNARK proof. 
+Other fields of the `RateLimitProof` message are the public inputs to the rln circuit as defined in [rln documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Public-Inputs).
+
+The `merkleRoot` indicates the root of the Merkle tree used for the generation of the `proof`. It is a 32-byte value.
+
+The `epoch` is used for the generation of the `proof`.  It is a 32-byte value. 
+<!-- TODO epoch is going to change to a different type -->
+
+`shareX` and `shareY` are shares of the user's identity key.
+These shares are created using Shamir's secret sharing scheme. 
+`shareX` is a 32-byte value and contains the hash of the `WakuMessage`'s `payload` concatenated with its `content_topic`. 
+<!-- TODO hash other fields if necessary-->
+`shareY` is also a 32-byte value which is calculated using [Shamir secret sharing scheme](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Linear-Equation-amp-SSS).
+
+The `nullifier` corresponds to the internal nullifier described in [rln documentation](https://hackmd.io/tMTLMYmTR5eynw2lwK9n1w?view#Nullifiers). 
+It allows specifying whether two messages are published by the same publisher during the same `epoch`.
+It is a 32-byte value.
+
 <!-- TODO to reflect this change on WakuMessage spec once the PR gets mature -->
 
 # Copyright


### PR DESCRIPTION
Inline with https://github.com/status-im/nim-waku/issues/714. 
I used snake_case field names as suggested in https://github.com/vacp2p/rfc/issues/346.