### PR TITLE
Add waku2 field definition

### DIFF
--- a/content/docs/rfcs/31/README.md
+++ b/content/docs/rfcs/31/README.md
@@ -51,7 +51,7 @@ Directly storing one or several multiaddresses in the ENR would fix the issues l
 
 # `multiaddrs` ENR key
 
-We propose the definition of the `multiaddrs` key.
+We define a  `multiaddrs` key.
 
 - The value MUST be a list of binary encoded multiaddr prefixed by their size.
 - The size of the multiaddr MUST be encoded in a Big Endian unsigned 16-bit integer.
@@ -120,7 +120,7 @@ In the future, an extension of this RFC could be made to support other elliptic 
 
 # `waku2` ENR key
 
-We propose the definition of a `waku2` field key:
+We define a `waku2` field key:
 
 - The value MUST be an 8-bit flag field,
 where bits set to `1` indicate `true` and bits set to `0` indicate `false` for the relevant flags.
@@ -132,7 +132,7 @@ with `bit 7` the most significant bit and `bit 0` the least significant bit.
 | `undef` | `undef` | `undef` | `undef` | `lightpush` | `filter` | `store` | `relay` |
 
 - In the scheme above, the flags `lightpush`, `filter`, `store` and `relay` correlates with support for protocols with the same name.
-If a protocol is not supported, the corresponding field MUST NOT be set to `true`.
+If a protocol is not supported, the corresponding field MUST be set to `false`.
 Indicating positive support for any specific protocol is OPTIONAL,
 though it MAY be required by the relevant application or discovery process.
 - Flags marked as `undef` is not yet defined.

--- a/content/docs/rfcs/31/README.md
+++ b/content/docs/rfcs/31/README.md
@@ -118,8 +118,42 @@ Supported key type is `secp256k1` only.
 
 In the future, an extension of this RFC could be made to support other elliptic curve cryptography such as `ed25519`.
 
+# `waku2` ENR key
+
+We propose the definition of a `waku2` field key:
+
+- The value MUST be an 8-bit flag field,
+where bits set to `1` indicate `true` and bits set to `0` indicate `false` for the relevant flags.
+- The flag values already defined are set out below,
+with `bit 7` the most significant bit and `bit 0` the least significant bit.
+
+| bit 7 | bit 6 | bit 5 | bit 4 | bit 3 | bit 2 | bit 1 | bit 0 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `undef` | `undef` | `undef` | `undef` | `lightpush` | `filter` | `store` | `relay` |
+
+- In the scheme above, the flags `lightpush`, `filter`, `store` and `relay` correlates with support for protocols with the same name.
+If a protocol is not supported, the corresponding field MUST NOT be set to `true`.
+Indicating positive support for any specific protocol is OPTIONAL,
+though it MAY be required by the relevant application or discovery process.
+- Flags marked as `undef` is not yet defined.
+These SHOULD be set to `false` by default.
+
+## Usage
+
+- A Waku v2 node MAY choose to populate the `waku2` field for enhanced discovery capabilities,
+such as indicating supported protocols.
+Such a node MAY indicate support for any specific protocol by setting the corresponding flag to `true`.
+- Waku v2 nodes that want to participate in [Node Discovery Protocol v5](https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md) [[4]](#references), however,
+MUST implement the `waku2` key with at least one flag set to `true`.
+- Waku v2 nodes that discovered other participants using Discovery v5,
+MUST filter out participant records that do not implement this field or do not have at least one flag set to `true`.
+- In addition, such nodes MAY choose to filter participants on specific flags (such as supported protocols),
+or further interpret the `waku2` field as required by the application.
+
+
 # References
 
 - [1] https://github.com/status-im/nim-waku/pull/690
 - [2] https://github.com/vacp2p/rfc/issues/462#issuecomment-943869940 
 - [3] https://eips.ethereum.org/EIPS/eip-778
+- [4] https://github.com/ethereum/devp2p/blob/master/discv5/discv5.md


### PR DESCRIPTION
This PR addresses a conversation that was started in https://github.com/status-im/nim-waku/pull/763.

It's a bit unconventional to open a PR towards an unmerged branch, but this seemed like the best place to continue the conversation.

It defines an 8-bit `waku2` flag field as a new ENR key-value pair. 

I didn't want to overdefine fields that are better suited to a TBD capability discovery mechanism, so added the minimum number of flags that would immediately be useful for coarse filtering in discv5, indicating support for `lightpush`, `filter`, `store` and `relay` protocols. Assuming we want to continue using an 8-bit field (only), there remains four flags for future definition, e.g. websockets, RLN, FT-store, etc.