### PR TITLE
Integrate RFC31. Delete RFC25.

### DIFF
--- a/content/docs/rfcs/10/README.md
+++ b/content/docs/rfcs/10/README.md
@@ -135,13 +135,24 @@ See [23/WAKU2-TOPICS](/spec/23) for more information about recommended topic usa
 
 ### Discovery domain
 
+#### Discovery methods
+
 Waku v2 can retrieve a list of nodes to connect to using DNS-based discovery as per [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459).
 While this is a useful way of bootstrapping connection to a set of peers,
-it MAY be used in conjunction with an [ambient peer discovery](https://docs.libp2p.io/concepts/publish-subscribe/#discovery) procedure to find still other nodes to connect to.
-Mechanisms for ambient peer discovery are not yet specified for Waku v2.
+it MAY be used in conjunction with an [ambient peer discovery](https://docs.libp2p.io/concepts/publish-subscribe/#discovery) procedure to find still other nodes to connect to,
+such as [Node Discovery v5](https://github.com/ethereum/devp2p/blob/8fd5f7e1c1ec496a9d8dc1640a8548b8a8b5986b/discv5/discv5.md).
+More ambient peer discovery methods are being tested for Waku v2,
+and will be specified for wider adoption.
 It is possible to bypass the discovery domain by specifying static nodes.
 
-<!-- TODO: Document (a) how we map ENR to multiaddr for EIP-1459, once specified, (b) ambient peer discovery. -->
+#### Use of ENR
+
+[31/WAKU2-ENR](/spec/31) describes the usage of [EIP-778 ENR (Ethereum Node Records)](https://eips.ethereum.org/EIPS/eip-778) for Waku v2 discovery purposes.
+It introduces two new ENR fields, `multiaddrs` and `waku2`, that a Waku v2 node MAY use for discovery purposes.
+These fields MUST be used under certain conditions, as set out in the spec.
+Both EIP-1459 DNS-based discovery and Node Discovery v5 operates on ENR,
+and it's reasonable to expect even wider utility for ENR in Waku v2 networks in future.
+
 
 ### Request/Reply domain
 
@@ -411,3 +422,9 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 18. [EIP-1459](https://eips.ethereum.org/EIPS/eip-1459)
 
 19. [Ambient peer discovery](https://docs.libp2p.io/concepts/publish-subscribe/#discovery)
+
+20. [Node Discovery v5](https://github.com/ethereum/devp2p/blob/8fd5f7e1c1ec496a9d8dc1640a8548b8a8b5986b/discv5/discv5.md)
+
+31. [31/WAKU2-ENR spec](/spec/31)
+
+32. [EIP-778](https://eips.ethereum.org/EIPS/eip-778)

--- a/content/docs/rfcs/25/README.md
+++ b/content/docs/rfcs/25/README.md
@@ -2,7 +2,7 @@
 slug: 25
 title: 25/LIBP2P-DNS-DISCOVERY
 name: Libp2p Peer Discovery via DNS
-status: raw
+status: deleted
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
 ---

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -7,7 +7,6 @@ bookMenuLevels: 1
   - [17/WAKU2-RLNRELAY]({{< relref "/docs/rfcs/17/README.md" >}})
   - [20/TOY-ETH-PM]({{< relref "/docs/rfcs/20/README.md" >}})
   - [24/STATUS-CURATION]({{< relref "/docs/rfcs/24/README.md" >}})
-  - [25/LIBP2P-DNS-DISCOVERY]({{< relref "/docs/rfcs/25/README.md" >}})
   - [28/STATUS-FEATURING]({{< relref "/docs/rfcs/28/README.md" >}})
   - [31/WAKU2-ENR]({{< relref "/docs/rfcs/31/README.md" >}})
 - Draft


### PR DESCRIPTION
This PR closes https://github.com/vacp2p/rfc/issues/473.

It integrates RFC31 into the Waku 2 suite, by referencing it in the discovery context in RFC10.
It also updates the status of RFC25 to "deleted", following the [COSS Lifecycle](https://rfc.vac.dev/spec/1/#coss-lifecycle).