### PR TITLE
Changes WakuInfo Field

### DIFF
--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -78,7 +78,7 @@ The following structured types are defined for use on the Debug API:
 
 | Field | Type | Inclusion | Description |
 | ----: | :---: | :---: |----------- |
-| `listenAddresses` | `Array`[`String`] | mandatory | Addresses that the node is listening for |
+| `listenAddresses` | `Array`[`String`] | mandatory | Listening addresses of the node |
 
 ### `get_waku_v2_debug_v1_info`
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -78,7 +78,7 @@ The following structured types are defined for use on the Debug API:
 
 | Field | Type | Inclusion | Description |
 | ----: | :---: | :---: |----------- |
-| `listenStr` | `String` | mandatory | Address that the node is listening for |
+| `listenAddresses` | `Array`[`String`] | mandatory | Addresses that the node is listening for |
 
 ### `get_waku_v2_debug_v1_info`
 


### PR DESCRIPTION
Currently, the RFC for WakuInfo Field is listenStr with type String, which suggests that there can be only a single address which the waku node is listening to. However, a wakunode can be listening to more than one address for eg, if it supports websockets, or webrtc.
This PR changes the field to listenAddresses , and type to Address of String , which is a more appropriate representation. 

Corresponding Implementation to PR:  https://github.com/status-im/nim-waku/pull/775#event-5667601507.