### PR TITLE
Edit/clarify relation to libp2p relay

### DIFF
--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -13,7 +13,7 @@ contributors:
 `11/WAKU2-RELAY` specifies a [Publish/Subscribe approach](https://docs.libp2p.io/concepts/publish-subscribe/) to peer-to-peer messaging with a strong focus on privacy, censorship-resistance, security and scalability.
 Its current implementation is a minor extension of the [libp2p GossipSub protocol](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md) and prescribes gossip-based dissemination.
 As such the scope is limited to defining a separate [`protocol id`](https://github.com/libp2p/specs/blob/master/connections/README.md#protocol-negotiation) for `11/WAKU2-RELAY`, establishing privacy and security requirements, and defining how the underlying GossipSub is to be interpreted and implemented within the Waku and cryptoeconomic domain.
-`11/WAKU2-RELAY` is not related to the [libp2p relay protocols](https://github.com/libp2p/specs/tree/master/relay).
+`11/WAKU2-RELAY` should not be confused with [libp2p circuit relay](https://github.com/libp2p/specs/tree/master/relay).
 
 **Protocol identifier**: `/vac/waku/relay/2.0.0`
 

--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -13,7 +13,7 @@ contributors:
 `11/WAKU2-RELAY` specifies a [Publish/Subscribe approach](https://docs.libp2p.io/concepts/publish-subscribe/) to peer-to-peer messaging with a strong focus on privacy, censorship-resistance, security and scalability.
 Its current implementation is a minor extension of the [libp2p GossipSub protocol](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md) and prescribes gossip-based dissemination.
 As such the scope is limited to defining a separate [`protocol id`](https://github.com/libp2p/specs/blob/master/connections/README.md#protocol-negotiation) for `11/WAKU2-RELAY`, establishing privacy and security requirements, and defining how the underlying GossipSub is to be interpreted and implemented within the Waku and cryptoeconomic domain.
-It is not related to the [libp2p relay protocols](https://github.com/libp2p/specs/tree/master/relay).
+`11/WAKU2-RELAY` is not related to the [libp2p relay protocols](https://github.com/libp2p/specs/tree/master/relay).
 
 **Protocol identifier**: `/vac/waku/relay/2.0.0`
 

--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -13,6 +13,7 @@ contributors:
 `11/WAKU2-RELAY` specifies a [Publish/Subscribe approach](https://docs.libp2p.io/concepts/publish-subscribe/) to peer-to-peer messaging with a strong focus on privacy, censorship-resistance, security and scalability.
 Its current implementation is a minor extension of the [libp2p GossipSub protocol](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/README.md) and prescribes gossip-based dissemination.
 As such the scope is limited to defining a separate [`protocol id`](https://github.com/libp2p/specs/blob/master/connections/README.md#protocol-negotiation) for `11/WAKU2-RELAY`, establishing privacy and security requirements, and defining how the underlying GossipSub is to be interpreted and implemented within the Waku and cryptoeconomic domain.
+It is not related to the [libp2p relay protocols](https://github.com/libp2p/specs/tree/master/relay).
 
 **Protocol identifier**: `/vac/waku/relay/2.0.0`
 


### PR DESCRIPTION
This PR clarifies that there is no relation between `11/WAKU2-RELAY` and [libp2p relay protocols](https://github.com/libp2p/specs/tree/master/relay).
When reading the  `11/WAKU2-RELAY` RFC and the [libp2p spec](https://github.com/libp2p/specs/blob/master/README.md#protocols), I was confused as I assumed at first they were related.