### PR TITLE
A few fixes on the rln-relay spec

### DIFF
--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -48,7 +48,7 @@ Note that  `sk` is initially only known by the owning peer however it may get ex
 
 <!-- diagram -->
 
-![Figure 1: Registration.](../../../../static/rfcs/17/rln-relay.png)
+![Figure 1: Registration.](../../../../rfcs/17/rln-relay.png)
 
 <!-- TODO: the function calls in this figure as well as messages are subject to change -->
 
@@ -107,7 +107,7 @@ An overview of slashing procedure is provided in Figure 2.
 
 <!-- TODO: may consider [validator functions](https://github.com/libp2p/specs/tree/master/pubsub#topic-validation) or [extended validators](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#extended-validators) for the spam detection -->
 
-![Figure 2: Publishing, Routing and Slashing workflow.](../../../../static/rfcs/17/rln-message-verification.png)
+![Figure 2: Publishing, Routing and Slashing workflow.](../../../../rfcs/17/rln-message-verification.png)
 
 <!-- TODO: the function calls in this figure as well as messages are subject to change -->
 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -154,13 +154,13 @@ message WakuMessage {
 
 The `proof` field is an array of 256 bytes and carries the zkSNARK proof as explained in the [Publishing process](##Publishing).
 The proof asserts that:
-1. The message publisher is the current member of the group i.e., her/his identity commitment key is part of the membership group Merkle tree with the root `merkleRoot`.
+1. The message publisher is the current member of the group i.e., her/his identity commitment key is part of the membership group Merkle tree with the root `merkle_root`.
 2. `share_x` and `share_y`  are correctly computed.
 3. The `nullifier` is constructed correctly.
 
 Other fields of the `RateLimitProof` message are the public inputs to the rln circuit and used for the generation of the `proof`.
 
-The `merkleRoot` is an array of 32 bytes which holds the root of membership group Merkle tree at the time of publishing the message.
+The `merkle_root` is an array of 32 bytes which holds the root of membership group Merkle tree at the time of publishing the message.
 
 The `epoch` is an array of 32 bytes that represents the epoch in which the message is published.
 <!-- TODO epoch is going to change to a different type -->


### PR DESCRIPTION
Fixes broken links and naming mismatches.