### PR TITLE
Changed PB Timestamp index to 10

### DIFF
--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -49,7 +49,7 @@ message WakuMessage {
   bytes payload = 1;
   string contentTopic = 2;
   uint32 version = 3;
-  sint64 timestamp = 4;
+  sint64 timestamp = 10;
 }
 ```
 


### PR DESCRIPTION
This is a fix to maintain retro-compatibility with `timestamp` protobuffer fields.

Timestamps now have `Timestamp` type (currently an alias for `int64`) and nanoseconds resolution. Their new protobuffer index is `10`.

Previous versions had timestamps as `float` with subseconds contained in the fractional part and protobuffer index `4`.

This PR is related to https://github.com/vacp2p/rfc/pull/483 and https://github.com/status-im/nim-waku/pull/842.