### PR TITLE
Adding 35/WAKU2-NOISE to menu

### DIFF
--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -9,6 +9,7 @@ bookMenuLevels: 1
   - [28/STATUS-FEATURING]({{< relref "/docs/rfcs/28/README.md" >}})
   - [31/WAKU2-ENR]({{< relref "/docs/rfcs/31/README.md" >}})
   - [32/RLN-SPEC]({{< relref "/docs/rfcs/32/README.md" >}})
+  - [35/WAKU2-NOISE]({{< relref "/docs/rfcs/35/README.md" >}})
 - Draft
   - [1/COSS]({{< relref "/docs/rfcs/1/README.md" >}})
   - [3/REMOTE-LOG]({{< relref "/docs/rfcs/3/README.md" >}})


### PR DESCRIPTION
In regards to https://github.com/vacp2p/rfc/pull/496, this PR adds a link to [35/WAKU2-NOISE](https://github.com/vacp2p/rfc/tree/master/content/docs/rfcs/35) in the left navigation menu.