### PR TITLE
RFC16: add version call

### DIFF
--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -89,6 +89,18 @@ The `get_waku_v2_debug_v1_info` method retrieves information about a Waku v2 nod
 
 none
 
+### `get_waku_v2_debug_v1_version`
+
+The `get_waku_v2_debug_v1_version` method retrieves the version of a Waku v2 node as a string.
+The version SHOULD follow [semantic versioning](https://semver.org/).
+In case the node's current build is based on a git commit between semantic versions,
+the retrieved version string MAY contain the git commit hash alone or in combination with the latest semantic version.
+
+#### Parameters
+
+none
+
+
 #### Response
 - [**`WakuInfo`**](#wakuinfo) - information about a Waku v2 node
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -81,6 +81,10 @@ The following structured types are defined for use on the Debug API:
 | `listenAddresses` | `Array`[`String`] | mandatory | Listening addresses of the node |
 | `enrUri` | `String` | optional | ENR URI of the node |
 
+#### WakuInfo
+
+`Version`
+
 ### `get_waku_v2_debug_v1_info`
 
 The `get_waku_v2_debug_v1_info` method retrieves information about a Waku v2 node
@@ -88,6 +92,11 @@ The `get_waku_v2_debug_v1_info` method retrieves information about a Waku v2 nod
 #### Parameters
 
 none
+
+#### Response
+
+- [**`WakuInfo`**](#wakuinfo) - information about a Waku v2 node
+
 
 ### `get_waku_v2_debug_v1_version`
 
@@ -100,9 +109,10 @@ the retrieved version string MAY contain the git commit hash alone or in combina
 
 none
 
-
 #### Response
-- [**`WakuInfo`**](#wakuinfo) - information about a Waku v2 node
+
+- **`string`** - represents the version of a Waku v2 node
+
 
 ## Relay API
 

--- a/content/docs/rfcs/16/README.md
+++ b/content/docs/rfcs/16/README.md
@@ -83,8 +83,6 @@ The following structured types are defined for use on the Debug API:
 
 #### WakuInfo
 
-`Version`
-
 ### `get_waku_v2_debug_v1_info`
 
 The `get_waku_v2_debug_v1_info` method retrieves information about a Waku v2 node


### PR DESCRIPTION
Specifies a debug RPC call returning a Waku node's version. This call is implemented in `nwaku` accordingly.