### PR TITLE
Protocol Fees in RLN contract RFC

### DIFF
--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -98,7 +98,7 @@ This function MUST fire the `MemberWithdrawn` event for each member slashed from
     * `event MemberWithdrawn(uint256 indexed pubkey, uint256 indexed index)`
 
 
-# Implementation Suggestions
+# Example Implementation
 
 Complete implementation of this contract can be found at https://github.com/vacp2p/rln-contract
 

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -8,14 +8,6 @@ tags: RLN
 editor: Keshav Gupta <keshav@status.im>
 contributors:
 ---
-
-## Tags
-
-Currently identified tags comprise
-
-* `17/WAKU-RLN-RELAY` protocol is an extension of `11/WAKU-RELAY` which additionally provides spam protection using Rate Limiting Nullifiers (RLN).
-
-
 # Abstract
 The following standard allows for the implementation of a standard API for Rate Limiting Nullifier Contract that manages membership of the participants in a peer-to-peer messaging group.
 This API is intended to be used in conjunction with [17/WAKU-RLN-RELAY](https://rfc.vac.dev/spec/17/).

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -4,7 +4,7 @@ title: 41/WAKU2-RLN-CONTRACT
 name: Rate Limiting Nullifier Membership Contract
 status: raw
 category: Standards Track
-tags: 17/WAKU-RLN-RELAY
+tags: RLN
 editor: Keshav Gupta <keshav@status.im>
 contributors:
 ---

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -3,7 +3,7 @@ slug: 41
 title: 41/WAKU2-RLN-CONTRACT
 name: Rate Limiting Nullifier Membership Contract
 status: raw
-category: RLN
+category: Standards Track
 tags: 17/WAKU-RLN-RELAY
 editor: Keshav Gupta <keshav@status.im>
 contributors:

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -40,7 +40,7 @@ This is done via the `register` function of the RLN membership contract.
 If a registered member of the RLN group spams messages in the network then its secret key get exposed which can be used to slash its membership from the group.
 This is done by calling the `withdraw` function of the RLN membership contract, which removes the member from the Merkle tree thereby revoking its rights to send any messages.
 
-# Wire Format Specification / Syntax
+# Contract Specification
 
 ### Constructor
 

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -57,6 +57,16 @@ This is done by calling the `withdraw` function of the RLN membership contract, 
     * `depth` is the depth of the Merkle tree that determines the maximum number of members to the RLN group.
     * `_poseidonHasher` is the address of the poseidon hasher contract used in the `hash` function.
 
+### Protocol Fees
+
+* `PROTOCOL_FEES_PERCENTAGE` is a portion of users' staked funds can be taken as the fee to use a private spam-protected gossips-sub network.
+This can also be seen as an incentive mechanism for node operators
+(where the collected funds are distributed among the operators like in DAOs)
+Providing better incentivization means attracting more platforms/operators/users, 
+therefore getting wider adoption of waku-rln-relay, 
+hence achieving better network robustness, 
+censorship-resistance, and anonymity as well as protocol sustainability. This parameter COULD be hard coded in the contract or set via the constructor.
+
 ### Methods
 
 * register: This function registers the `pubkey` to the list of members.
@@ -72,13 +82,15 @@ This function MUST fire the `MemberRegistered` event for each registered member.
     * `function registerBatch(uint256[] calldata pubkeys) external payable`
 
 
-* withdraw: This function accepts the `secret` of the public key at index`_pubkeyIndex` to withdraw the ETH equal to the`membershipDeposit` to the `receiver` address.
+* withdraw: This function accepts the `secret` of the public key at index`_pubkeyIndex` to withdraw the ETH equal to the`membershipDeposit` to the `receiver` address. 
+If the `PROTOCOL_FEES_PERCENTAGE` is used in the contract then it MUST be subtracted from the`membershipDeposit`. 
 This function MUST remove the associated member from the list of members.
 This function MUST fire the `MemberWithdrawn` event.
     * `function withdraw(uint256 secret, uint256 _pubkeyIndex, address payable receiver) external`
 
 
 * withdrawBatch: This function accepts multiple `secrets` of the public keys at the indices `pubkeyIndexes` to withdraw the ETH equal to the `membershipDeposit * secrets.length` to the `receiver` address.
+If the `PROTOCOL_FEES_PERCENTAGE` is used in the contract then it MUST be subtracted from the`membershipDeposit`.
 This function MUST remove the associated members from the list of members.
 This function MUST fire the `MemberWithdrawn` event for each member slashed from the group.
     * `function withdrawBatch(uint256[] calldata secrets, uint256[] calldata pubkeyIndexes, address payable[] calldata receivers) external`

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -9,11 +9,11 @@ editor: Keshav Gupta <keshav@status.im>
 contributors:
 ---
 # Abstract
-The following standard allows for the implementation of a standard API for Rate Limiting Nullifier Contract that manages membership of the participants in a peer-to-peer messaging group.
+The following standard specifies a standard API for Rate Limiting Nullifier Contract that manages membership of the participants in a peer-to-peer messaging group.
 This API is intended to be used in conjunction with [17/WAKU-RLN-RELAY](https://rfc.vac.dev/spec/17/).
 Peers that violate the messaging rate in a relay network,
 like explained in [11/WAKU2-RELAY](https://rfc.vac.dev/spec/11/),
-are considered spammers and their message is considered spam.
+are considered spammers and their messages are considered spam.
 Spammers are financially punished and removed from the system.
 Rate limiting nullifier (RLN), like explained in [32/RLN](https://rfc.vac.dev/spec/32/),
 a construct based on zero-knowledge proofs that provides an anonymous rate-limited signaling/messaging framework suitable for decentralized (and centralized) environments.

--- a/content/docs/rfcs/41/README.md
+++ b/content/docs/rfcs/41/README.md
@@ -104,6 +104,12 @@ Complete implementation of this contract can be found at https://github.com/vacp
 
 The contract for Poseidon Hasher can be found at https://github.com/vacp2p/rln-contract/blob/main/contracts/PoseidonHasher.sol
 
+## References
+
+1. [17/WAKU-RLN-RELAY](https://rfc.vac.dev/spec/17/)
+2. [11/WAKU2-RELAY](https://rfc.vac.dev/spec/11/)
+3. [32/RLN](https://rfc.vac.dev/spec/32/)
+
 # Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This change to the RFC takes into consideration the protocol fees and hence deducts it as commission from the staked funds during withdrawal. Refer to https://github.com/vacp2p/rfc/issues/485 and https://github.com/vacp2p/rln-contract/pull/5