### PR TITLE
Proposal: Add ephemeral flag to wakuMessage

### DIFF
--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -23,7 +23,7 @@ Nevertheless, in case that storage provider nodes cannot afford high availabilit
 
 The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
 Nodes running [13/WAKU2-STORE](/spec/13) SHOULD support "ephemeral" messages as specified in [14/WAKU2-MESSAGE](/spec/14).
-Nodes running [13/WAKU2-STORE](/spec/13) SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
+Nodes running [13/WAKU2-STORE](/spec/13) SHOULD NOT store messages with the `ephemeral` flag set to `true`.
 
 
 # Security Consideration

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -8,6 +8,7 @@ editor: Sanaz Taheri <sanaz@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>
   - Oskar Thorén <oskar@status.im>
+  - Aaryamann Challani <aaryamann@status.im>
 ---
 
 This specification explains the Waku `13/WAKU2-STORE` protocol which enables querying of messages received through relay protocol and stored by other nodes. 

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -21,7 +21,7 @@ As such, they are required to be *highly available* and in specific have a *high
 The high uptime requirement makes sure that no message is missed out hence a complete and intact view of the message history is delivered to the querying nodes.
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
-The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
+The concept of "ephemeral" messages introduced in `[14/WAKU2-MESSAGE](/spec/14)` affects `13/WAKU2-STORE` as well.
 Nodes running [13/WAKU2-STORE](/spec/13) SHOULD support "ephemeral" messages as specified in [14/WAKU2-MESSAGE](/spec/14).
 Nodes running [13/WAKU2-STORE](/spec/13) SHOULD NOT store messages with the `ephemeral` flag set to `true`.
 

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -22,13 +22,8 @@ The high uptime requirement makes sure that no message is missed out hence a com
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
 The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
-
-Any `WakuMessage` that has the `ttl` field set to `0` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
-Nodes SHOULD NOT not store messages with the `ttl` field set to `0`.
-
-Nodes SHOULD store messages which satisfy the following constraints -
-1. `ttl > currentTime + Thr`, where `Thr` describes the network latency as well as clock asynchrony.
-2. `ttl` is unset, for backwards compatibility.
+Any `WakuMessage` that has the `ephemeral` flag set to `true` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
+Nodes SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
 
 # Security Consideration
 

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -21,6 +21,8 @@ As such, they are required to be *highly available* and in specific have a *high
 The high uptime requirement makes sure that no message is missed out hence a complete and intact view of the message history is delivered to the querying nodes.
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
+The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well. Any `WakuMessage` that has the ephemeral flag set to true will not be added to the store, thereby reducing the amount of one-time use messages on disk. While the node SHOULD not store messages with the ephemeral flag set to true, they MAY do so for archival.
+
 # Security Consideration
 
 The main security consideration to take into account while using `13/WAKU2-STORE` is that a querying node have to reveal their content filters of interest to the queried node, hence potentially compromising their privacy.

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -22,8 +22,13 @@ The high uptime requirement makes sure that no message is missed out hence a com
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
 The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
-Any `WakuMessage` that has the `ephemeral` flag set to `true` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
-Nodes SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
+
+Any `WakuMessage` that has the `ttl` field set to `0` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
+Nodes SHOULD NOT not store messages with the `ttl` field set to `0`.
+
+Nodes SHOULD store messages which satisfy the following constraints -
+1. `ttl > currentTime + Thr`, where `Thr` describes the network latency as well as clock asynchrony.
+2. `ttl` is unset, for backwards compatibility.
 
 # Security Consideration
 

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -21,7 +21,9 @@ As such, they are required to be *highly available* and in specific have a *high
 The high uptime requirement makes sure that no message is missed out hence a complete and intact view of the message history is delivered to the querying nodes.
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
-The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well. Any `WakuMessage` that has the ephemeral flag set to true will not be added to the store, thereby reducing the amount of one-time use messages on disk. While the node SHOULD not store messages with the ephemeral flag set to true, they MAY do so for archival.
+The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
+Any `WakuMessage` that has the `ephemeral` flag set to `true` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
+Nodes SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
 
 # Security Consideration
 

--- a/content/docs/rfcs/13/README.md
+++ b/content/docs/rfcs/13/README.md
@@ -22,8 +22,9 @@ The high uptime requirement makes sure that no message is missed out hence a com
 Nevertheless, in case that storage provider nodes cannot afford high availability, the querying nodes may retrieve the historical messages from multiple sources to achieve a full and intact view of the past.
 
 The concept of "ephemeral" messages exists while using `13/WAKU2-STORE` as well.
-Any `WakuMessage` that has the `ephemeral` flag set to `true` MAY be ignored by the store service node, thereby reducing the amount of one-time use messages stored.
-Nodes SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
+Nodes running [13/WAKU2-STORE](/spec/13) SHOULD support "ephemeral" messages as specified in [14/WAKU2-MESSAGE](/spec/14).
+Nodes running [13/WAKU2-STORE](/spec/13) SHOULD NOT not store messages with the `ephemeral` flag set to `true`.
+
 
 # Security Consideration
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -39,8 +39,8 @@ This field holds the Unix epoch time in nanoseconds.
 Omitting it means the timestamp is unspecified.
 
 The `ephemeral` field MAY be set to signify the transient nature of the message.
-If the message SHOULD be stored, then this field MUST be set to `false`, which is equivalent to omitting the field.
-If the message SHOULD NOT be stored, then this field MUST be set to `true`.
+If the message SHOULD be [stored](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
+If the message SHOULD NOT be [stored](/spec/13), then this field MUST be set to `true`.
 
 See [13/WAKU2-STORE](/spec/13) for more details.
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -38,8 +38,10 @@ The `timestamp` field MAY be filled out to signify the time at which the message
 This field holds the Unix epoch time in nanoseconds. 
 Omitting it means the timestamp is unspecified.
 
-The `ephemeral` field MAY be filled out to signify the transient nature of the message.
-Omitting it means the message is permananent, and must be added to the store.
+The `ephemeral` field MAY be set to signify the transient nature of the message.
+If the message SHOULD be stored, then this field MUST be set to `false`, which is equivalent to omitting the field.
+If the message SHOULD NOT be stored, then this field MUST be set to `true`.
+
 See [13/WAKU2-STORE](/spec/13) for more details.
 
 ## Payloads

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -39,8 +39,8 @@ This field holds the Unix epoch time in nanoseconds.
 Omitting it means the timestamp is unspecified.
 
 The `ephemeral` field MAY be set to signify the transient nature of the message.
-If the message SHOULD be [stored](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
-If the message SHOULD NOT be [stored](/spec/13), then this field MUST be set to `true`.
+If the message SHOULD be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
+If the message SHOULD NOT be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
 
 See [13/WAKU2-STORE](/spec/13) for more details.
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -38,9 +38,9 @@ The `timestamp` field MAY be filled out to signify the time at which the message
 This field holds the Unix epoch time in nanoseconds. 
 Omitting it means the timestamp is unspecified.
 
-The `ephemeral` field MAY be set to signify the transient nature of the message.
-If the message SHOULD be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
-If the message SHOULD NOT be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
+The `ttl` field MAY be filled out to signify the time at which the message must be considered invalid.
+This field holds the Unix epoch time in nanoseconds.
+Omitting it means the timestamp is unspecified, and by extension, the message SHOULD be stored without a time-to-live.
 
 See [13/WAKU2-STORE](/spec/13) for more details.
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -6,6 +6,7 @@ status: draft
 editor: Oskar Thorén <oskar@status.im>
 contributors:
   - Sanaz Taheri <sanaz@status.im>
+  - Aaryamann Challani <aaryamann@status.im>
 ---
 
 This specification provides a way to encapsulate messages sent over Waku with specific information security goals.

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -108,6 +108,12 @@ For example, a malicious node can arbitrarily set the  `timestamp` of a `WakuMes
 Applications using the `WakuMessage`'s `timestamp` field are recommended to use additional methods for more robust message ordering.
 An example of how to deal with message ordering against adversarial message timestamps can be found in the Status protocol, see [6/PAYLOADS](https://specs.status.im/spec/6#clock-vs-timestamp-and-message-ordering).
 
+## Reliability of the ephemeral flag
+
+The `ephemeral` field in `WakuMessage` is set by the sender.
+Since there is currently no incentive mechanism for nodes that implement [13/WAKU2-STORE](/spec/13) and [11/WAKU2-RELAY](/spec/11) to behave correctly, this field is inherently unsecure.
+Malicious nodes that implement [11/WAKU2-RELAY](/spec/11) can flip the value of the ephemeral flag, and nodes that receive such messages would have no mechanism to verify the integrity of the message.
+
 # Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -38,6 +38,10 @@ The `timestamp` field MAY be filled out to signify the time at which the message
 This field holds the Unix epoch time in nanoseconds. 
 Omitting it means the timestamp is unspecified.
 
+The `ephemeral` field MAY be filled out to signify the transient nature of the message.
+Omitting it means the message is permananent, and must be added to the store.
+See [13/WAKU2-STORE](/spec/13) for more details.
+
 ## Payloads
 
 Payloads are implemented using [protocol buffers v3](https://developers.google.com/protocol-buffers/).
@@ -50,6 +54,7 @@ message WakuMessage {
   string contentTopic = 2;
   uint32 version = 3;
   sint64 timestamp = 10;
+  bool ephemeral = 31;
 }
 ```
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -40,7 +40,7 @@ Omitting it means the timestamp is unspecified.
 
 The `ephemeral` field MAY be set to signify the transient nature of the message.
 If the message should be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
-If the message SHOULD NOT be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
+If the message should not be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
 
 See [13/WAKU2-STORE](/spec/13) for more details.
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -38,9 +38,9 @@ The `timestamp` field MAY be filled out to signify the time at which the message
 This field holds the Unix epoch time in nanoseconds. 
 Omitting it means the timestamp is unspecified.
 
-The `ttl` field MAY be filled out to signify the time at which the message must be considered invalid.
-This field holds the Unix epoch time in nanoseconds.
-Omitting it means the timestamp is unspecified, and by extension, the message SHOULD be stored without a time-to-live.
+The `ephemeral` field MAY be set to signify the transient nature of the message.
+If the message SHOULD be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
+If the message SHOULD NOT be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
 
 See [13/WAKU2-STORE](/spec/13) for more details.
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -39,7 +39,7 @@ This field holds the Unix epoch time in nanoseconds.
 Omitting it means the timestamp is unspecified.
 
 The `ephemeral` field MAY be set to signify the transient nature of the message.
-If the message SHOULD be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
+If the message should be stored by the [store protocol](/spec/13), then this field MUST be set to `false`, which is equivalent to omitting the field.
 If the message SHOULD NOT be stored by the [store protocol](/spec/13), then this field MUST be set to `true`.
 
 See [13/WAKU2-STORE](/spec/13) for more details.


### PR DESCRIPTION
Adds the `ephemeral` flag to 14/WAKU2-MESSAGE and discusses its usage in 13/WAKU2-STORE

Edit: This PR is purely for the ephemeral field, but based on a suggestion by @LNSD, there emerges a way to use ttl's with just one field - https://github.com/vacp2p/rfc/pull/532#issuecomment-1239413675. However, there has been some discussion against usage of a ttl field owing to the complexity associated with it - https://github.com/vacp2p/rfc/pull/532#issuecomment-1240512609

Reverting the changes made relating to the `ttl` field