### PR TITLE
update(lightpush): dandelion

### DIFF
--- a/content/docs/rfcs/19/README.md
+++ b/content/docs/rfcs/19/README.md
@@ -4,12 +4,12 @@ title: 19/WAKU2-LIGHTPUSH
 name: Waku v2 Light Push
 status: draft
 editor: Oskar Thorén <oskar@status.im>
-contributors:
+contributors: Daniel Kaiser <danielkaiser@status.im>
 ---
 
 **Protocol identifier**: `/vac/waku/lightpush/2.0.0-beta1`
 
-# Motivation and goals
+# Motivation and Goals
 
 Light nodes with short connection windows and limited bandwidth wish to publish messages into the Waku network.
 Additionally, there is sometimes a need for confirmation that a message has been received "by the network"
@@ -40,18 +40,28 @@ message PushRPC {
 }
 ```
 
-## Message relaying
+## Message Relaying
 
-Nodes that respond to `PushRequests` MUST relay this via [11/WAKU2-RELAY](/spec/11) protocol on the specified `pubsub_topic`.
+Nodes that respond to `PushRequests` MUST either
+relay the encapsulated message via [11/WAKU2-RELAY](/spec/11) protocol on the specified `pubsub_topic`,
+or forward the `PushRequest` via 19/LIGHTPUSH on a [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/) stem.
 If they are unable to do so for some reason, they SHOULD return an error code in `PushResponse`.
 
-## Security considerations
+## Security Considerations
 
-Since this can introduce amplification factor, it is RECOMMENDED for the node relaying to the rest of the network to extra precaution.
-This can be done by various forms of rate limiting, or by using [18/WAKU2-SWAP](/spec/18) to account for the service provided.
+Since this can introduce an amplification factor, it is RECOMMENDED for the node relaying to the rest of the network to take extra precautions.
+This can be done by rate limiting via [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/),
+or by using [18/WAKU2-SWAP](/spec/18) to account for the service provided.
 
 Note that the above is currently not fully implemented.
 
 # Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+* [11/WAKU2-RELAY](/spec/11)
+* [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/)
+* [18/WAKU2-SWAP](/spec/18)
+

--- a/content/docs/rfcs/19/README.md
+++ b/content/docs/rfcs/19/README.md
@@ -50,8 +50,7 @@ If they are unable to do so for some reason, they SHOULD return an error code in
 ## Security Considerations
 
 Since this can introduce an amplification factor, it is RECOMMENDED for the node relaying to the rest of the network to take extra precautions.
-This can be done by rate limiting via [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/),
-or by using [18/WAKU2-SWAP](/spec/18) to account for the service provided.
+This can be done by rate limiting via [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/).
 
 Note that the above is currently not fully implemented.
 
@@ -63,5 +62,4 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 * [11/WAKU2-RELAY](/spec/11)
 * [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/)
-* [18/WAKU2-SWAP](/spec/18)
 

--- a/content/docs/rfcs/19/README.md
+++ b/content/docs/rfcs/19/README.md
@@ -11,10 +11,9 @@ contributors:
 
 # Motivation and goals
 
-Light nodes with short connection windows and limited bandwidth wish to publish
-messages into the Waku network. Additionally, there is sometimes a need for
-confirmation that a message has been received "by the network" (here, at least
-one node).
+Light nodes with short connection windows and limited bandwidth wish to publish messages into the Waku network.
+Additionally, there is sometimes a need for confirmation that a message has been received "by the network"
+(here, at least one node).
 
 `19/WAKU2-LIGHTPUSH` is a request/response protocol for this.
 
@@ -48,7 +47,8 @@ If they are unable to do so for some reason, they SHOULD return an error code in
 
 ## Security considerations
 
-Since this can introduce amplification factor, it is RECOMMENDED for the node relaying to the rest of the network to extra precaution. This can be done by various forms of rate limiting, or by using [18/WAKU2-SWAP](/spec/18) to account for the service provided.
+Since this can introduce amplification factor, it is RECOMMENDED for the node relaying to the rest of the network to extra precaution.
+This can be done by various forms of rate limiting, or by using [18/WAKU2-SWAP](/spec/18) to account for the service provided.
 
 Note that the above is currently not fully implemented.
 


### PR DESCRIPTION
This PR updates [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/):

* allowing relayers to optionally relay via [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/)
* suggest [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/) for rate limiting to avoid amplification
* remove [SWAP](https://rfc.vac.dev/spec/18/) reference, as we currently focus on RLN
* some editing to align the RFC with the updated [1/COSS](https://rfc.vac.dev/spec/1/) and template

Since [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/) is already in `draft` state:
*Changes to draft specifications should be done in consultation with users*
(Feel free to add more reviewers.)

These changes should not pose a problem, as they are fully backwards compatible.
The main impact on [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/) users is that message delivery can be subject to increased delay if relayed via [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/).
Note: Users of [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/) also had no guarantee of delivery or latency before this update.

## Alternative

Alternatively, we could introduce a new protocol for [44/WAKU2-DANDELION](https://rfc.vac.dev/spec/44/) stem,
or a flag in [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/) `PushRequest`s that allows to opt-in to (or opt-out of) Dandelion stem.

The current solution is the simplest and allows [19/WAKU2-LIGHTPUSH](https://rfc.vac.dev/spec/19/)  users to benefit from anonymity properties added by Dandelion. It also increases the size of the Dandelion anonymity set.