### PR TITLE
feat(17/WAKU2-RLN-RELAY): acceptable window of roots updated on per-block basis

### DIFF
--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -117,11 +117,10 @@ This is to prevent a newly registered peer from spamming the system by messaging
 ### Merkle Root Validation
 The routing peers MUST check whether the provided Merkle root in the `RateLimitProof` is valid.
 It can do so by maintaining a local set of valid Merkle roots, which consist of `acceptable_root_window_size` past roots.
-These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
-The Merkle roots are updated on a per-block instead of a per-event basis.
-This is done since a large number of group changes in a single block may fully replace the acceptable window of roots.
-
-Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block.
+These roots refer to the final state of the Merkle tree after a whole block consisting of group changes is processed.
+The Merkle roots are updated on a per-block basis instead of a per-event basis.
+This is done because if Merkle roots are updated on a per-event basis, some peers could send messages with a root that refers to a Merkle tree state that might get invalidated while the message is still propagating in the network, due to many registrations happening during this time frame.
+By updating roots on a per-block basis instead, we will have only one root update per-block processed, regardless on how many registrations happened in a block, and peers will be able to successfully propagate messages in a time frame corresponding to roughly the size of the roots window times the block mining time. 
 
 For example, if the relaying peer has a window size of 5, and there are 10 registrations in the last block, this would lead to the acceptable window of roots to represent the last 5 registration events it has received.
 However, if it fails to process even one event in the block, this would lead to the whole window of acceptable roots being invalid.

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -120,11 +120,15 @@ It can do so by maintaining a local set of valid Merkle roots, which consist of 
 These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
 The Merkle roots are updated on a per-block instead of a per-event basis.
 This is done since a large number of group changes in a single block may fully replace the acceptable window of roots.
+
 Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block.
+
 For example, if the relaying peer has a window size of 5, and there are 10 registrations in the last block, this would lead to the acceptable window of roots to represent the last 5 registration events it has received.
 However, if it fails to process even one event in the block, this would lead to the whole window of acceptable roots being invalid.
 This would lead to the relayer invalidating all messages that it sees, and it would also not be able to broadcast valid messages.
+
 Atomic processing of the blocks are necessary so that even if the peer is unable to process one event, the previous roots remain valid, and can be used to generate valid RateLimitProof's.
+
 This also allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
 This network delay is related to the nature of asynchronous network conditions, which means that peers see membership changes asynchronously, and therefore may have differing local Merkle trees.
 See [Recommended System Parameters](#recommended-system-parameters) on choosing an appropriate `acceptable_root_window_size`. 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -118,7 +118,9 @@ This is to prevent a newly registered peer from spamming the system by messaging
 The routing peers MUST check whether the provided Merkle root in the `RateLimitProof` is valid.
 It can do so by maintaining a local set of valid Merkle roots, which consist of `acceptable_root_window_size` past roots.
 These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
-The Merkle roots are updated on a per-block instead of a per-event basis since a large number of group changes in a single block may fully populate the acceptable window of roots, effectively preventing some peers from sending messages with a root that refers to the state of the Merkle tree at a previous block. 
+The Merkle roots are updated on a per-block instead of a per-event basis.
+This is done since a large number of group changes in a single block may fully populate the acceptable window of roots.
+Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block. 
 This allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
 This network delay is related to the nature of asynchronous network conditions, which means that peers see membership changes asynchronously, and therefore may have differing local Merkle trees.
 See [Recommended System Parameters](#recommended-system-parameters) on choosing an appropriate `acceptable_root_window_size`. 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -123,8 +123,7 @@ This is done because if Merkle roots are updated on a per-event basis, some peer
 By updating roots on a per-block basis instead, we will have only one root update per-block processed, regardless on how many registrations happened in a block, and peers will be able to successfully propagate messages in a time frame corresponding to roughly the size of the roots window times the block mining time. 
 
 For example, if the relaying peer has a window size of 5, and there are 10 registrations in the last block, this would lead to the acceptable window of roots to represent the last 5 registration events it has received.
-However, if it fails to process even one event in the block, this would lead to the whole window of acceptable roots being invalid.
-This would lead to the relayer invalidating all messages that it sees, and it would also not be able to broadcast valid messages.
+This would lead to the relayer invalidating all messages with older roots.
 
 Atomic processing of the blocks are necessary so that even if the peer is unable to process one event, the previous roots remain valid, and can be used to generate valid RateLimitProof's.
 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -172,7 +172,7 @@ message WakuMessage {
   optional uint32 version = 3;
   optional sint64 timestamp = 10;
   optional bool ephemeral = 31;
-  bytes rate_limit_proof = 21;
++  optional bytes rate_limit_proof = 21;
 }
 
 ```

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -170,7 +170,7 @@ message WakuMessage {
   optional uint32 version = 3;
   optional sint64 timestamp = 10;
   optional bool ephemeral = 31;
-+ RateLimitProof rate_limit_proof = 21;
+  bytes rate_limit_proof = 21;
 }
 
 ```

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -119,7 +119,7 @@ The routing peers MUST check whether the provided Merkle root in the `RateLimitP
 It can do so by maintaining a local set of valid Merkle roots, which consist of `acceptable_root_window_size` past roots.
 These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
 The Merkle roots are updated on a per-block instead of a per-event basis.
-This is done since a large number of group changes in a single block may fully populate the acceptable window of roots.
+This is done since a large number of group changes in a single block may fully replace the acceptable window of roots.
 Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block. 
 This allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
 This network delay is related to the nature of asynchronous network conditions, which means that peers see membership changes asynchronously, and therefore may have differing local Merkle trees.

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -94,6 +94,9 @@ Proof generation relies on the knowledge of Merkle tree root `merkle_root` and `
 Getting access to the Merkle tree can be done in various ways. 
 One way is that all the peers construct the tree locally.
 This can be done by listening to the registration and deletion events emitted by the membership contract.
+Peers MUST update the local Merkle tree on a per-block basis.
+This is discussed further in the [Merkle Root Validation](#merkle-root-validation) section.
+
 Another approach for synchronizing the state of slashed `pk`s is to disseminate such information through a p2p GossipSub network to which all peers are subscribed. 
 This is in addition to sending the deletion transaction to the membership contract.
 The benefit of an off-chain slashing is that it allows real-time removal of spammers as opposed to on-chain slashing in which peers get informed with a delay,
@@ -106,24 +109,26 @@ The reason is that using an old root can allow inference about the index of the 
 Upon the receipt of a PubSub message via [`11/WAKU2-RELAY`](/spec/11) protocol, the routing peer parses the `data` field as a `WakuMessage` and gets access to the `RateLimitProof` field.  
 The peer then validates the `RateLimitProof`  as explained next.
 
-**Epoch Validation**
+### Epoch Validation
 If the `epoch` attached to the message is more than `max_epoch_gap` apart from the routing peer's current `epoch` then the message is discarded and considered invalid.
 This is to prevent a newly registered peer from spamming the system by messaging for all the past epochs. 
 `max_epoch_gap` is a system parameter for which we provide some recommendations in section [Recommended System Parameters](#recommended-system-parameters).
 
-**Merkle Root Validation**
+### Merkle Root Validation
 The routing peers MUST check whether the provided Merkle root in the `RateLimitProof` is valid.
 It can do so by maintaining a local set of valid Merkle roots, which consist of `acceptable_root_window_size` past roots.
+These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
+The Merkle roots are updated on a per-block instead of a per-event basis since a large number of group changes in a single block may fully populate the acceptable window of roots, effectively preventing some peers from sending messages with a root that refers to the state of the Merkle tree at a previous block. 
 This allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
 This network delay is related to the nature of asynchronous network conditions, which means that peers see membership changes asynchronously, and therefore may have differing local Merkle trees.
 See [Recommended System Parameters](#recommended-system-parameters) on choosing an appropriate `acceptable_root_window_size`. 
 
-**Proof Verification**
+### Proof Verification
 The routing peers MUST check whether the zero-knowledge proof `proof` is valid.
 It does so by running the zk verification algorithm as explained in [RLN](/spec/32). 
 If `proof` is invalid then the message is discarded. 
 
-**Spam detection**
+### Spam detection
 To enable local spam detection and slashing, routing peers MUST record the `nullifier`, `share_x`, and `share_y` of incoming messages which are not discarded i.e., not found spam or with invalid proof or epoch.
 To spot spam messages, the peer checks whether a message with an identical `nullifier` has already been relayed. 
 1. If such a message exists and its `share_x` and `share_y` components are different from the incoming message, then slashing takes place.
@@ -161,9 +166,10 @@ message RateLimitProof {
 
 message WakuMessage {
   bytes payload = 1;
-  string contentTopic = 2;
-  uint32 version = 3;
-  double timestamp = 4;
+  string content_topic = 2;
+  optional uint32 version = 3;
+  optional sint64 timestamp = 10;
+  optional bool ephemeral = 31;
 + RateLimitProof rate_limit_proof = 21;
 }
 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -120,8 +120,12 @@ It can do so by maintaining a local set of valid Merkle roots, which consist of 
 These roots refer to the final state of the Merkle tree after a whole block consisting of group changes are processed.
 The Merkle roots are updated on a per-block instead of a per-event basis.
 This is done since a large number of group changes in a single block may fully replace the acceptable window of roots.
-Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block. 
-This allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
+Updating the whole window would lead to some peers sending invalid messages with a root that refers to the state of the Merkle tree at a previous block.
+For example, if the relaying peer has a window size of 5, and there are 10 registrations in the last block, this would lead to the acceptable window of roots to represent the last 5 registration events it has received.
+However, if it fails to process even one event in the block, this would lead to the whole window of acceptable roots being invalid.
+This would lead to the relayer invalidating all messages that it sees, and it would also not be able to broadcast valid messages.
+Atomic processing of the blocks are necessary so that even if the peer is unable to process one event, the previous roots remain valid, and can be used to generate valid RateLimitProof's.
+This also allows peers which are not well connected to the network to be able to send messages, accounting for network delay.
 This network delay is related to the nature of asynchronous network conditions, which means that peers see membership changes asynchronously, and therefore may have differing local Merkle trees.
 See [Recommended System Parameters](#recommended-system-parameters) on choosing an appropriate `acceptable_root_window_size`. 
 

--- a/content/docs/rfcs/17/README.md
+++ b/content/docs/rfcs/17/README.md
@@ -122,9 +122,6 @@ The Merkle roots are updated on a per-block basis instead of a per-event basis.
 This is done because if Merkle roots are updated on a per-event basis, some peers could send messages with a root that refers to a Merkle tree state that might get invalidated while the message is still propagating in the network, due to many registrations happening during this time frame.
 By updating roots on a per-block basis instead, we will have only one root update per-block processed, regardless on how many registrations happened in a block, and peers will be able to successfully propagate messages in a time frame corresponding to roughly the size of the roots window times the block mining time. 
 
-For example, if the relaying peer has a window size of 5, and there are 10 registrations in the last block, this would lead to the acceptable window of roots to represent the last 5 registration events it has received.
-This would lead to the relayer invalidating all messages with older roots.
-
 Atomic processing of the blocks are necessary so that even if the peer is unable to process one event, the previous roots remain valid, and can be used to generate valid RateLimitProof's.
 
 This also allows peers which are not well connected to the network to be able to send messages, accounting for network delay.


### PR DESCRIPTION
In https://github.com/waku-org/nwaku/pull/1349, we introduced atomic block processing in waku-rln-relay so that poorly connected peers may still participate in messaging if they don't see the latest block. This PR updates the RFC according to the code.
