### PR TITLE
docs: improved filter specification

### DIFF
--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -94,6 +94,7 @@ message FilterSubscribeResponse {
 // Protocol identifier: /vac/waku/filter-push/2.0.0-beta1
 message MessagePush {
   WakuMessage waku_message = 1;
+  optional string pubsub_topic = 2;
 }
 ```
 
@@ -202,6 +203,8 @@ We consider `1 minute` to be a reasonable default.
 
 Each message MUST be pushed in a `MessagePush` message.
 Each `MessagePush` MUST contain one (and only one) `waku_message`.
+If this message was received on a specific `pubsub_topic`,
+it SHOULD be included in the `MessagePush`.
 A filter client SHOULD NOT respond to a `MessagePush`.
 Since the filter protocol does not include caching or fault-tolerance,
 this is a best effort push service with no bundling or retransmission of messages.

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -104,7 +104,6 @@ A filter service node MUST support the _filter-subscribe_ protocol
 to allow filter clients to subscribe, modify, refresh and unsubscribe a desired set of filter criteria.
 The combination of different filter criteria for a specific filter client node is termed a "subscription".
 A filter client is interested in receiving messages matching the filter criteria in its registered subscriptions.
-It is RECOMMENDED that filter service nodes allow only one subscription per client.
 
 Since a filter service node is consuming resources to provide this service,
 it MAY account for usage and adapt its service provision to certain clients.

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -149,6 +149,7 @@ requests that the service node SHOULD indicate if it has any active subscription
 The filter client SHOULD exclude any filter criteria from the request.
 The filter service node SHOULD respond with a success code if it has any active subscriptions for this client
 or an error code if not.
+The filter service node SHOULD ignore any filter criteria in the request.
 
 #### SUBSCRIBE
 

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -4,7 +4,7 @@ title: 12/WAKU2-FILTER
 name: Waku v2 Filter
 status: draft
 tags: waku-core
-versions: [00](/spec/12/previous-versions/00/), 01
+versions: [00](/spec/12/previous-versions/00/)
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -130,13 +130,11 @@ In addition, the filter service node MAY choose to provide a more detailed statu
 In the description of each request type below,
 the term "filter criteria" refers to the combination of `pubsub_topic` and a set of `content_topics`.
 The request MAY include filter criteria, conditional to the selected `filter_subscribe_type`.
-The `pubsub_topic` is always optional in filter criteria.
+If the request contains filter criteria,
+it MUST contain a `pubsub_topic`
+and the `content_topics` set MUST NOT be empty.
 A `WakuMessage` matches filter criteria when its `content_topic` is in the `content_topics` set
-and, if included in the criteria, it was published on a matching `pubsub_topic`.
-If the `pubsub_topic` is set and not empty,
-a `WakuMessage` will only match the filter criteria if it has a matching `content_topic` and was published on _the same_ `pubsub_topic`.
-If the `pubsub_topic` is either empty or unset,
-a `WakuMessage` will match the filter criteria if it has a matching `content_topic` and was published on _any_ `pubsub_topic`.
+and it was published on a matching `pubsub_topic`.
 
 ### Filter Subscribe Types
 
@@ -162,6 +160,9 @@ A client MAY use this request type to _refresh_ an existing subscription
 by providing _the same_ filter criteria in a new request.
 The filter service node SHOULD respond with a success code if it successfully honored this request
 or an error code if not.
+The filter service node SHOULD respond with an error code and discard the request
+if the subscribe request does not contain valid filter criteria,
+i.e. both a `pubsub_topic` _and_ a non-empty `content_topics` set.
 
 #### UNSUBSCRIBE
 
@@ -172,6 +173,9 @@ A client MAY use this request type to _modify_ an existing subscription
 by providing _a subset of_ the original filter criteria to unsubscribe from in a new request.
 The filter service node SHOULD respond with a success code if it successfully honored this request
 or an error code if not.
+The filter service node SHOULD respond with an error code and discard the request
+if the unsubscribe request does not contain valid filter criteria,
+i.e. both a `pubsub_topic` _and_ a non-empty `content_topics` set.
 
 #### UNSUBSCRIBE_ALL
 

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -215,6 +215,9 @@ A filter client SHOULD NOT respond to a `MessagePush`.
 Since the filter protocol does not include caching or fault-tolerance,
 this is a best effort push service with no bundling
 or guaranteed retransmission of messages.
+A filter client SHOULD verify that each `MessagePush` it receives
+originated from a service node where the client has an active subscription
+and that it matches filter criteria belonging to that subscription.
 
 --- 
 # Future Work

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -194,6 +194,8 @@ These [`WakuMessage`s](./waku-message.md) are likely to come from [`11/WAKU2-REL
 but there MAY be other sources or protocols where this comes from.
 This is up to the consumer of the protocol.
 
+If a message push fails,
+the filter service node MAY consider the client node to be unreachable.
 If a specific filter client node is not reachable from the service node for a period of time,
 the filter service node MAY choose to stop pushing messages to the client and remove its subscription.
 This period is up to the service node implementation.
@@ -207,7 +209,8 @@ If this message was received on a specific `pubsub_topic`,
 it SHOULD be included in the `MessagePush`.
 A filter client SHOULD NOT respond to a `MessagePush`.
 Since the filter protocol does not include caching or fault-tolerance,
-this is a best effort push service with no bundling or retransmission of messages.
+this is a best effort push service with no bundling
+or guaranteed retransmission of messages.
 
 --- 
 # Future Work

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -4,7 +4,9 @@ title: 12/WAKU2-FILTER
 name: Waku v2 Filter
 status: draft
 tags: waku-core
-versions: [00](/spec/12/previous-versions/00/)
+versions:
+  - 00 </spec/12/previous-versions/00/>
+  - 01
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -4,6 +4,7 @@ title: 12/WAKU2-FILTER
 name: Waku v2 Filter
 status: draft
 tags: waku-core
+versions: [00](/spec/12/previous-versions/00/), 01
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -16,9 +16,9 @@ contributors:
 
 # Content filtering
 
-**Protocol identifiers***:
-_filter-subscribe_: `/vac/waku/filter-subscribe/2.0.0-beta1`
-_filter-push_: `/vac/waku/filter-push/2.0.0-beta1`
+**Protocol identifiers**:
+- _filter-subscribe_: `/vac/waku/filter-subscribe/2.0.0-beta1`
+- _filter-push_: `/vac/waku/filter-push/2.0.0-beta1`
 
 Content filtering is a way to do [message-based
 filtering](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern#Message_filtering).

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -16,7 +16,9 @@ contributors:
 
 # Content filtering
 
-**Protocol identifier***: `/vac/waku/filter/2.0.0-beta1`
+**Protocol identifiers***:
+_filter-subscribe_: `/vac/waku/filter-subscribe/2.0.0-beta1`
+_filter-push_: `/vac/waku/filter-push/2.0.0-beta1`
 
 Content filtering is a way to do [message-based
 filtering](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern#Message_filtering).
@@ -61,77 +63,148 @@ The following are not considered as part of the adversarial model:
 ## Protobuf
 
 ```protobuf
-message FilterRequest {
-  bool subscribe = 1;
-  string topic = 2;
-  repeated ContentFilter contentFilters = 3;
+syntax = "proto3";
 
-  message ContentFilter {
-    string contentTopic = 1;
+// 12/WAKU2-FILTER rfc: https://rfc.vac.dev/spec/12/
+package waku.filter.v2;
+
+// Protocol identifier: /vac/waku/filter-subscribe/2.0.0-beta1
+message FilterSubscribeRequest {
+  enum FilterSubscribeType {
+    SUBSCRIBER_PING = 0;
+    SUBSCRIBE = 1;
+    UNSUBSCRIBE = 2;
+    UNSUBSCRIBE_ALL = 3;
   }
+
+  string request_id = 1;
+  FilterSubscribeType filter_subscribe_type = 2;
+
+  // Filter criteria
+  optional string pubsub_topic = 10;
+  repeated string content_topics = 11;
 }
 
+message FilterSubscribeResponse {
+  string request_id = 1;
+  uint32 status_code = 10;
+  optional string status_desc = 11;
+}
+
+// Protocol identifier: /vac/waku/filter-push/2.0.0-beta1
 message MessagePush {
-  repeated WakuMessage messages = 1;
-}
-
-message FilterRPC {
-  string requestId = 1;
-  FilterRequest request = 2;
-  MessagePush push = 3;
+  WakuMessage waku_message = 1;
 }
 ```
 
-#### FilterRPC
+## Filter-Subscribe
 
-A node MUST send all Filter messages (`FilterRequest`, `MessagePush`) wrapped inside a
-`FilterRPC` this allows the node handler to determine how to handle a message as the Waku
-Filter protocol is not a request response based protocol but instead a push based system.
+A filter service node MUST support the _filter-subscribe_ protocol
+to allow filter clients to subscribe, modify, refresh and unsubscribe a desired set of filter criteria.
+The combination of different filter criteria for a specific filter client node is termed a "subscription".
+A filter client is interested in receiving messages matching the filter criteria in its registered subscriptions.
+It is RECOMMENDED that filter service nodes allow only one subscription per client.
 
-The `requestId` MUST be a uniquely generated string. When a `MessagePush` is sent
-the `requestId` MUST match the `requestId` of the subscribing `FilterRequest` whose filters
-matched the message causing it to be pushed.
+Since a filter service node is consuming resources to provide this service,
+it MAY account for usage and adapt its service provision to certain clients.
+An incentive mechanism is currently planned but underspecified.
 
-#### FilterRequest
+### Filter Subscribe Request
 
-A `FilterRequest` contains an optional topic, zero or more content filters and
-a boolean signifying whether to subscribe or unsubscribe to the given filters.
-True signifies 'subscribe' and false signifies 'unsubscribe'.
+A client node MUST send all filter requests in a `FilterSubscribeRequest` message.
+This request MUST contain a `request_id`.
+The `request_id` MUST be a uniquely generated string.
+Each request MUST include a `filter_subscribe_type`, indicating the type of request.
 
-A node that sends the RPC with a filter request and `subscribe` set to 'true' 
-requests that the filter node SHOULD notify the light requesting node of messages
-matching this filter.
+### Filter Subscribe Response
 
-A node that sends the RPC with a filter request and `subscribe` set to 'false'
-requests that the filter node SHOULD stop notifying the light requesting node
-of messages matching this filter if it is currently doing so.
+In return to any `FilterSubscribeRequest`,
+a filter service node SHOULD respond with a `FilterSubscribeResponse` with a `requestId` matching that of the request.
+This response MUST contain a `status_code` indicating if the request was successful or not.
+Successful status codes are in the `2xx` range.
+Client nodes SHOULD consider all other status codes as error codes and assume that the requested operation had failed.
+In addition, the filter service node MAY choose to provide a more detailed status description in the `status_desc` field.
 
-The filter matches when content filter and, optionally, a topic is matched.
-Content filter is matched when a `WakuMessage` `contentTopic` field is the same.
+### Filter matching
 
-A filter node SHOULD honor this request, though it MAY choose not to do so. If
-it chooses not to do so it MAY tell the light why. The mechanism for doing this
-is currently not specified. For notifying the light node a filter node sends a
-MessagePush message.
+In the description of each request type below,
+the term "filter criteria" refers to the combination of `pubsub_topic` and a set of `content_topics`.
+The request MAY include filter criteria, conditional to the selected `filter_subscribe_type`.
+The `pubsub_topic` is always optional in filter criteria.
+A `WakuMessage` matches filter criteria when its `content_topic` is in the `content_topics` set
+and, if included in the criteria, it was published on a matching `pubsub_topic`.
+If the `pubsub_topic` is set and not empty,
+a `WakuMessage` will only match the filter criteria if it has a matching `content_topic` and was published on _the same_ `pubsub_topic`.
+If the `pubsub_topic` is either empty or unset,
+a `WakuMessage` will match the filter criteria if it has a matching `content_topic` and was published on _any_ `pubsub_topic`.
 
-Since such a filter node is doing extra work for a light node, it MAY also
-account for usage and be selective in how much service it provides. This
-mechanism is currently planned but underspecified.
+### Filter Subscribe Types
 
-#### MessagePush
+The following filter subscribe types are defined:
 
-A filter node that has received a filter request SHOULD push all messages that
-match this filter to a light node. These [`WakuMessage`'s](./waku-message.md) are likely to come from the
-`relay` protocol and be kept at the Node, but there MAY be other sources or
-protocols where this comes from. This is up to the consumer of the protocol.
+#### SUBSCRIBER_PING
 
-A filter node MUST NOT send a push message for messages that have not been
-requested via a FilterRequest.
+A filter client that sends a `FilterSubscribeRequest` with `filter_subscribe_type` set to `SUBSCRIBER_PING`
+requests that the service node SHOULD indicate if it has any active subscriptions for this client.
+The filter client SHOULD exclude any filter criteria from the request.
+The filter service node SHOULD respond with a success code if it has any active subscriptions for this client
+or an error code if not.
 
-If a specific light node isn't connected to a filter node for some specific
-period of time (e.g. a TTL), then the filter node MAY choose to not push these
-messages to the node. This period is up to the consumer of the protocol and node
-implementation, though a reasonable default is one minute.
+#### SUBSCRIBE
+
+A filter client that sends a `FilterSubscribeRequest` with `filter_subscribe_type` set to `SUBSCRIBE`
+requests that the service node SHOULD push messages matching this filter to the client.
+The filter client MUST include the desired filter criteria in the request.
+A client MAY use this request type to _modify_ an existing subscription
+by providing _additional_ filter criteria in a new request.
+A client MAY use this request type to _refresh_ an existing subscription
+by providing _the same_ filter criteria in a new request.
+The filter service node SHOULD respond with a success code if it successfully honored this request
+or an error code if not.
+
+#### UNSUBSCRIBE
+
+A filter client that sends a `FilterSubscribeRequest` with `filter_subscribe_type` set to `UNSUBSCRIBE`
+requests that the service node SHOULD _stop_ pushing messages matching this filter to the client.
+The filter client MUST include the filter criteria it desires to unsubscribe from in the request.
+A client MAY use this request type to _modify_ an existing subscription
+by providing _a subset of_ the original filter criteria to unsubscribe from in a new request.
+The filter service node SHOULD respond with a success code if it successfully honored this request
+or an error code if not.
+
+#### UNSUBSCRIBE_ALL
+
+A filter client that sends a `FilterSubscribeRequest` with `filter_subscribe_type` set to `UNSUBSCRIBE_ALL`
+requests that the service node SHOULD _stop_ pushing messages matching _any_ filter to the client.
+The filter client SHOULD exclude any filter criteria from the request.
+The filter service node SHOULD remove any existing subscriptions for this client.
+It SHOULD respond with a success code if it successfully honored this request
+or an error code if not.
+
+## Filter-Push
+
+A filter client node MUST support the _filter-push_ protocol
+to allow filter service nodes to push messages matching registered subscriptions to this client.
+
+A filter service node SHOULD push all messages
+matching the filter criteria in a registered subscription
+to the subscribed filter client.
+These [`WakuMessage`s](./waku-message.md) are likely to come from [`11/WAKU2-RELAY`](https://rfc.vac.dev/spec/11/),
+but there MAY be other sources or protocols where this comes from.
+This is up to the consumer of the protocol.
+
+If a specific filter client node is not reachable from the service node for a period of time,
+the filter service node MAY choose to stop pushing messages to the client and remove its subscription.
+This period is up to the service node implementation.
+We consider `1 minute` to be a reasonable default.
+
+### Message Push
+
+Each message MUST be pushed in a `MessagePush` message.
+Each `MessagePush` MUST contain one (and only one) `waku_message`.
+A filter client SHOULD NOT respond to a `MessagePush`.
+Since the filter protocol does not include caching or fault-tolerance,
+this is a best effort push service with no bundling or retransmission of messages.
 
 --- 
 # Future Work

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -4,15 +4,17 @@ title: 12/WAKU2-FILTER
 name: Waku v2 Filter
 status: draft
 tags: waku-core
-versions:
-  - 00 </spec/12/previous-versions/00/>
-  - 01
+version: 01
 editor: Hanno Cornelius <hanno@status.im>
 contributors:
   - Dean Eigenmann <dean@status.im>
   - Oskar Thorén <oskar@status.im>
   - Sanaz Taheri <sanaz@status.im>
   - Ebube Ud <ebube@status.im>
+---
+
+previous versions: [00](/spec/12/previous-versions/00/)
+
 ---
 
 `WakuFilter` is a protocol that enables subscribing to messages that a peer receives. This is a more lightweight version of `WakuRelay` specifically designed for bandwidth restricted devices. This is due to the fact that light nodes subscribe to full-nodes and only receive the messages they desire.

--- a/content/docs/rfcs/12/previous-versions/00/README.md
+++ b/content/docs/rfcs/12/previous-versions/00/README.md
@@ -1,0 +1,169 @@
+---
+slug: 12
+title: 12/WAKU2-FILTER
+name: Waku v2 Filter
+status: draft
+tags: waku-core
+editor: Hanno Cornelius <hanno@status.im>
+contributors:
+  - Dean Eigenmann <dean@status.im>
+  - Oskar Thorén <oskar@status.im>
+  - Sanaz Taheri <sanaz@status.im>
+  - Ebube Ud <ebube@status.im>
+---
+
+`WakuFilter` is a protocol that enables subscribing to messages that a peer receives. This is a more lightweight version of `WakuRelay` specifically designed for bandwidth restricted devices. This is due to the fact that light nodes subscribe to full-nodes and only receive the messages they desire.
+
+# Content filtering
+
+**Protocol identifier***: `/vac/waku/filter/2.0.0-beta1`
+
+Content filtering is a way to do [message-based
+filtering](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern#Message_filtering).
+Currently the only content filter being applied is on `contentTopic`. This
+corresponds to topics in Waku v1.
+
+## Rationale
+
+Unlike the `store` protocol for historical messages, this protocol allows for
+native lower latency scenarios such as instant messaging. It is thus
+complementary to it.
+
+Strictly speaking, it is not just doing basic request response, but performs
+sender push based on receiver intent. While this can be seen as a form of light
+pub/sub, it is only used between two nodes in a direct fashion. Unlike the
+Gossip domain, this is meant for light nodes which put a premium on bandwidth.
+No gossiping takes place.
+
+It is worth noting that a light node could get by with only using the `store`
+protocol to query for a recent time window, provided it is acceptable to do
+frequent polling.
+
+
+# Design Requirements
+
+The effectiveness and reliability of the content filtering service enabled by  `WakuFilter` protocol rely on the *high availability* of the full nodes as the service providers. To this end, full nodes must feature *high uptime* (to persistently listen and capture the network messages) as well as *high Bandwidth* (to provide timely message delivery to the light nodes). 
+
+# Security Consideration
+
+Note that while using `WakuFilter` allows light nodes to save bandwidth, it comes with a privacy cost in the sense that they need to disclose their liking topics to the full nodes to retrieve the relevant messages. Currently, anonymous subscription is not supported by the `WakuFilter`, however, potential solutions in this regard are sketched below in [Future Work](#future-work) section. 
+
+## Terminology
+The term Personally identifiable information (PII) refers to any piece of data that can be used to uniquely identify a user. For example, the signature verification key, and the hash of one's static IP address are unique for each user and hence count as PII.
+
+# Adversarial Model
+Any node running the `WakuFilter` protocol i.e., both the subscriber node and the queried node are considered as an adversary. Furthermore, we consider the adversary as a passive entity that attempts to collect information from other nodes to conduct an attack but it does so without violating protocol definitions and instructions. For example, under the passive adversarial model, no malicious node intentionally hides the messages matching to one's subscribed content filter as it is against the description of the `WakuFilter` protocol. 
+
+The following are not considered as part of the adversarial model: 
+  - An adversary with a global view of all the nodes and their connections. 
+  - An adversary that can eavesdrop on communication links between arbitrary pairs of nodes (unless the adversary is one end of the communication). In specific, the communication channels are assumed to be secure.
+
+## Protobuf
+
+```protobuf
+message FilterRequest {
+  bool subscribe = 1;
+  string topic = 2;
+  repeated ContentFilter contentFilters = 3;
+
+  message ContentFilter {
+    string contentTopic = 1;
+  }
+}
+
+message MessagePush {
+  repeated WakuMessage messages = 1;
+}
+
+message FilterRPC {
+  string requestId = 1;
+  FilterRequest request = 2;
+  MessagePush push = 3;
+}
+```
+
+#### FilterRPC
+
+A node MUST send all Filter messages (`FilterRequest`, `MessagePush`) wrapped inside a
+`FilterRPC` this allows the node handler to determine how to handle a message as the Waku
+Filter protocol is not a request response based protocol but instead a push based system.
+
+The `requestId` MUST be a uniquely generated string. When a `MessagePush` is sent
+the `requestId` MUST match the `requestId` of the subscribing `FilterRequest` whose filters
+matched the message causing it to be pushed.
+
+#### FilterRequest
+
+A `FilterRequest` contains an optional topic, zero or more content filters and
+a boolean signifying whether to subscribe or unsubscribe to the given filters.
+True signifies 'subscribe' and false signifies 'unsubscribe'.
+
+A node that sends the RPC with a filter request and `subscribe` set to 'true' 
+requests that the filter node SHOULD notify the light requesting node of messages
+matching this filter.
+
+A node that sends the RPC with a filter request and `subscribe` set to 'false'
+requests that the filter node SHOULD stop notifying the light requesting node
+of messages matching this filter if it is currently doing so.
+
+The filter matches when content filter and, optionally, a topic is matched.
+Content filter is matched when a `WakuMessage` `contentTopic` field is the same.
+
+A filter node SHOULD honor this request, though it MAY choose not to do so. If
+it chooses not to do so it MAY tell the light why. The mechanism for doing this
+is currently not specified. For notifying the light node a filter node sends a
+MessagePush message.
+
+Since such a filter node is doing extra work for a light node, it MAY also
+account for usage and be selective in how much service it provides. This
+mechanism is currently planned but underspecified.
+
+#### MessagePush
+
+A filter node that has received a filter request SHOULD push all messages that
+match this filter to a light node. These [`WakuMessage`'s](./waku-message.md) are likely to come from the
+`relay` protocol and be kept at the Node, but there MAY be other sources or
+protocols where this comes from. This is up to the consumer of the protocol.
+
+A filter node MUST NOT send a push message for messages that have not been
+requested via a FilterRequest.
+
+If a specific light node isn't connected to a filter node for some specific
+period of time (e.g. a TTL), then the filter node MAY choose to not push these
+messages to the node. This period is up to the consumer of the protocol and node
+implementation, though a reasonable default is one minute.
+
+--- 
+# Future Work
+<!-- Alternative title: Filter-subscriber unlinkability -->
+**Anonymous filter subscription**: This feature guarantees that nodes can anonymously subscribe for a message filter (i.e., without revealing their exact content filter). As such, no adversary in the `WakuFilter` protocol would be able to link nodes to their subscribed content filers. The current version of the `WakuFilter` protocol does not provide anonymity as the subscribing node has a direct connection to the full node and explicitly submits its content filter to be notified about the matching messages. However, one can consider preserving anonymity through one of the following ways: 
+- By hiding the source of the subscription i.e., anonymous communication. That is the subscribing node shall hide all its PII in its filter request e.g., its IP address. This can happen by the utilization of a proxy server or by using Tor<!-- TODO: if nodes have to disclose their PeerIDs (e.g., for authentication purposes) when connecting to other nodes in the WakuFilter protocol, then Tor does not preserve anonymity since it only helps in hiding the IP. So, the PeerId usage in switches must be investigated further. Depending on how PeerId is used, one may be able to link between a subscriber and its content filter despite hiding the IP address-->. 
+  Note that the current structure of filter requests i.e., `FilterRPC` does not embody any piece of PII, otherwise, such data fields must be treated carefully to achieve anonymity. 
+- By deploying secure 2-party computations in which the subscribing node obtains the messages matching a content filter whereas the full node learns nothing about the content filter as well as the messages pushed to the subscribing node. Examples of such 2PC protocols are [Oblivious Transfers](https://link.springer.com/referenceworkentry/10.1007%2F978-1-4419-5906-5_9#:~:text=Oblivious%20transfer%20(OT)%20is%20a,information%20the%20receiver%20actually%20obtains.) and one-way Private Set Intersections (PSI).
+
+# Changelog
+
+### Next
+
+- Added initial threat model and security analysis.
+   
+### 2.0.0-beta2
+
+Initial draft version. Released [2020-10-28](https://github.com/vacp2p/specs/commit/5ceeb88cee7b918bb58f38e7c4de5d581ff31e68)
+- Fix: Ensure contentFilter is a repeated field, on implementation
+- Change: Add ability to unsubscribe from filters. Make `subscribe` an explicit boolean indication. Edit protobuf field order to be consistent with libp2p.
+
+### 2.0.0-beta1
+
+Initial draft version. Released [2020-10-05](https://github.com/vacp2p/specs/commit/31857c7434fa17efc00e3cd648d90448797d107b)
+
+# Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+1. [Message Filtering (Wikipedia)](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern#Message_filtering)
+
+2. [Libp2p PubSub spec - topic validation](https://github.com/libp2p/specs/tree/master/pubsub#topic-validation)


### PR DESCRIPTION
This PR addresses https://github.com/vacp2p/rfc/issues/469 and https://github.com/waku-org/pm/issues/5

It proposes a change to the Filter protocol to:
- provide improved reliability mechanisms
- simplify the protobuf
- decouple the protocol-id required by the filter client from that of the filter service node, and
- provide for workflows that I expect will be useful for existing client applications.

### Why two protocol IDs for a single protocol?

Note that this is a single protocol, but uses @richard-ramos's [idea](https://github.com/waku-org/nwaku/issues/1423) of using two different libp2p protocol-ids. This will enable simple capability discovery based on libp2p-identify and is needed for nodes (e.g. Status Desktop instances) to provide a filter service to resource restricted nodes.

### What to review?

Please review the:
- wire format
- suggested protocol functions

I have deliberately not changed the RFC structure to conform to the template, so that the proposed changes are more visible in the diff.
The protobuf will also be added to the [protobuf repository](https://github.com/vacp2p/waku) and compiled for consistency checks.
These will be done in subsequent PRs. The idea in this PR is simply to reach agreement on protocol IDs, protobuf structure and overall functionality/scope.

### Some remarks/questions

1. In terms of reliability guarantees: service nodes should be able to "ghost" client nodes and ignore requests that they don't want to fulfill without justifying themselves. Reliability verification therefore lies with the filter client. This version of the protocol is designed to give the filter client enough tools to do this.
2. Note that `MessagePush` contains only a single `WakuMessage`. This is because service nodes should simply forward matching messages to the clients without any caching/bundling in this version of filter protocol. `Store` protocol is the only caching protocol and can be used in combination with `filter` to provide cached messages matching specific filter criteria.
3. ~~I'm still ambivalent on whether this `waku_message` needs to be nested in a `MessagePush` at all or if we simply forward the raw `WakuMessage` over the wire when pushing.~~ UPDATE: @richard-ramos pointed out that we also need the `pubsub_topic` for every Push, so the nesting is necessary.
4. Will the lightweight "subscriber-ping" mechanism and _refresh_ workflow be useful to clients? Would especially appreciate the input of client implementations on the sufficiency/reasonability of the proposal here (cc @fryorcraken @richard-ramos @prichodko). I imagine typical workflow being:
	1. client subscribes to multiple filter service nodes for redundancy, deduplicates messages locally
	2. client keeps filter subscriptions/connections alive using the lightweight ping mechanism with some frequency
	3. client occasionally uses the more expensive refresh mechanism (repeating the `SUBSCRIBE`) to ensure subscription continuity