### PR TITLE
update: topic naming

### DIFF
--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -101,7 +101,7 @@ waku/2/waku-9_shard-9/
 
 This indicates explicitly that the network traffic has been partitioned into 10 buckets.
 
-Besides named sharing, [51/WAKU2-RELAY-SHARDING](/spec/51) specifies two more sharing methods: static sharding and automatic sharding.
+Besides named sharding, [51/WAKU2-RELAY-SHARDING](/spec/51) specifies two more sharding methods: static sharding and automatic sharding.
 
 ## Content topics
 

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -3,47 +3,65 @@ slug: 23
 title: 23/WAKU2-TOPICS
 name: Waku v2 Topic Usage Recommendations
 status: draft
+category: Informational
 editor: Oskar Thoren <oskar@status.im>
 contributors:
   - Hanno Cornelius <hanno@status.im>
+  - Daniel Kaiser <danielkaiser@status.im>
 ---
 
-This document outlines recommended usage of topics in Waku v2.
+This document outlines recommended usage of topic names in Waku v2.
 In [10/WAKU2 spec](/spec/10) there are two types of topics:
 
 - PubSub topics, used for routing
 - Content topics, used for content-based filtering
 
+
 ## PubSub topics
 
 PubSub topics are used for routing of messages, see [11/WAKU2-RELAY](/spec/11) spec for more details of how this routing works.
 
-As written in [10/WAKU2 spec](/spec/10) there is a default PubSub topic:
+[51/WAKU2-RELAY-SHARDING](/spec/51) specifies Relay sharding,
+which allows sharding Waku Relay into a hierarchical set of shards.
+This document (23/WAKU2-TOPICS) comprises recommendations for naming pubsub topics,
+and acts as an informational source for *named sharding*.
+Named sharding is one of the sharding strategies specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
 
-`/waku/2/default-waku/proto`
+The Waku v2 default PubSub topic is:
+
+`/waku/2/default-waku/`
 
 This indicates that
 
-1) It relates to the Waku problem domain
+1) It relates to the Waku protocol domain
 2) version is 2
 3) `default-waku` indicates that it is the default topic for exchanging WakuMessages
-4) that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf as determined by WakuMessage
+
+> *Note*: In previous versions of this document, the default topic was `/waku/2/default-waku/proto`.
+The now deprecated `/proto` part indicated that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf.
+The inspiration for this format was taken from
+[Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages).
+However, because the payload of messages transmitted over [11/WAKU2-RELAY](/spec/11) must be a [14/WAKU2-MESSAGE](/spec/14),
+which specifies the wire format as protobuf,`/proto` is the only valid encoding.
+This makes the `/proto` indication obsolete.
+The encoding of the `payload` field of a Waku Message is indicated by the /{encoding} part of the content topic name.
+Specifying an encoding is only significant for the actual payload/data field.
+Waku preserves this option by allowing to specify an encoding for the WakuMessage payload field as part of the content topic name.
 
 ### PubSub topic format
 
 PubSub topics SHOULD follow the following structure:
 
-`/waku/2/{topic-name}/{encoding}`
+`/waku/2/{topic-name}`
 
-This namespaced structure makes things like compatibility and discoverability and automatic handling of new topics easier.
-For example, if the encoding of the payload is changed, compression is introduced, etc.
+This namespaced structure makes things like compatibility, discoverability, and automatic handling of new topics easier.
+If applicable, it is RECOMMENDED to structure `{topic-name}` in a hierarchical way as well.
+For example, `/waku/2/rs/0/2`, where `rs/0/2` is a hierarchically structured `{topic-name}`.
 
-For more on this format of PubSub topics, see [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages) where inspiration for this format was taken from.
 
 ### Default PubSub topic
 
 Unless there's a good reason, the default PubSub topic SHOULD be used for all protocols.
-However, in certain situations other topics MAY be used.
 
 Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
 See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
@@ -65,30 +83,25 @@ Let's say we have two different topics that are both experience heavy traffic bu
 This can be segregated into:
 
 ```
-/waku/2/status/proto
-/waku/2/walletconnect/proto
+/waku/2/status/
+/waku/2/walletconnect/
 ```
 
 This indicates that they are WakuMessages but for different domains completely.
 
 ### Topic sharding example
 
-Topic sharding is currently not supported by default, but is planned for the future in order to deal with increased network traffic.
-Here's an example of what this might look like:
+The following is an example of named sharing, as specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
 
 ```
-waku/2/waku-9_shard-0/proto
+waku/2/waku-9_shard-0/
 ...
-waku/2/waku-9_shard-9/proto
+waku/2/waku-9_shard-9/
 ```
 
 This indicates explicitly that the network traffic has been partitioned into 10 buckets.
 
-### Compression example
-
-Not yet implemented, but would be easy to add with:
-
-`/waku/2/default-waku/proto_snappy`
+Besides named sharing, [51/WAKU2-RELAY-SHARDING](/spec/51) specifies two more sharing methods: static sharding and automatic sharding.
 
 ## Content topics
 
@@ -184,3 +197,5 @@ Copyright and related rights waived via
 8. [15/WAKU-BRIDGE](/spec/15)
 
 9. [26/WAKU-PAYLOAD](/spec/26)
+
+10. [51/WAKU2-RELAY-SHARDING](/spec/51)

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -13,83 +13,64 @@ contributors:
 This document outlines recommended usage of topic names in Waku v2.
 In [10/WAKU2 spec](/spec/10) there are two types of topics:
 
-- PubSub topics, used for routing
+- pubsub topics, used for routing
 - Content topics, used for content-based filtering
 
 
-## PubSub topics
+## Pubsub Topics
 
-PubSub topics are used for routing of messages, see [11/WAKU2-RELAY](/spec/11) spec for more details of how this routing works.
+Pubsub topics are used for routing of messages (see [11/WAKU2-RELAY](/spec/11)),
+and can be named implicitly by Waku sharding (see [51/WAKU2-RELAY-SHARDING](/spec/51)).
+This document comprises recommendations for explicitly naming pubsub topics (e.g. when choosing *named sharding* as specified in [51/WAKU2-RELAY-SHARDING](/spec/51)).
 
-[51/WAKU2-RELAY-SHARDING](/spec/51) specifies Relay sharding,
-which allows sharding Waku Relay into a hierarchical set of shards.
-This document (23/WAKU2-TOPICS) comprises recommendations for naming pubsub topics,
-and acts as an informational source for *named sharding*.
-Named sharding is one of the sharding strategies specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
+### Pubsub Topic Format
 
-The Waku v2 default PubSub topic is:
+Pubsub topics SHOULD follow the following structure:
 
-`/waku/2/default-waku/`
+`/waku/2/{topic-name}`
 
-This indicates that
+This namespaced structure makes compatibility, discoverability, and automatic handling of new topics easier.
 
-1) It relates to the Waku protocol domain
-2) version is 2
-3) `default-waku` indicates that it is the default topic for exchanging WakuMessages
+The first two parts indicate
 
-> *Note*: In previous versions of this document, the default topic was `/waku/2/default-waku/proto`.
-The now deprecated `/proto` part indicated that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf.
+1) it relates to the Waku protocol domain, and
+2) the version is 2.
+
+If applicable, it is RECOMMENDED to structure `{topic-name}` in a hierarchical way as well.
+
+> *Note*: In previous versions of this document, the structure was `/waku/2/{topic-name}/{encoding}`.
+The now deprecated `/{encoding}` was always set to `/proto`,
+which indicated that the [data field](/spec/11/#protobuf-definition) in pubsub is serialized/encoded as protobuf.
 The inspiration for this format was taken from
 [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages).
 However, because the payload of messages transmitted over [11/WAKU2-RELAY](/spec/11) must be a [14/WAKU2-MESSAGE](/spec/14),
 which specifies the wire format as protobuf,`/proto` is the only valid encoding.
 This makes the `/proto` indication obsolete.
-The encoding of the `payload` field of a Waku Message is indicated by the /{encoding} part of the content topic name.
+The encoding of the `payload` field of a Waku Message is indicated by the `/{encoding}` part of the content topic name.
 Specifying an encoding is only significant for the actual payload/data field.
 Waku preserves this option by allowing to specify an encoding for the WakuMessage payload field as part of the content topic name.
 
-### PubSub topic format
+### Default PubSub Topic
 
-PubSub topics SHOULD follow the following structure:
+The Waku v2 default pubsub topic is:
 
-`/waku/2/{topic-name}`
+`/waku/2/default-waku/proto`
 
-This namespaced structure makes things like compatibility, discoverability, and automatic handling of new topics easier.
-If applicable, it is RECOMMENDED to structure `{topic-name}` in a hierarchical way as well.
-For example, `/waku/2/rs/0/2`, where `rs/0/2` is a hierarchically structured `{topic-name}`.
+The `{topic name}` part is `default-waku/proto`, which indicates it is default topic for exchanging WakuMessages;
+`/proto` remains for backwards compatibility.
 
+### Application Specific Names
 
-### Default PubSub topic
-
-Unless there's a good reason, the default PubSub topic SHOULD be used for all protocols.
-
-Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
-See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
-
-If you use another PubSub topic, be aware that:
-
-- Metadata protection might be weakened
-- Nodes subscribing to other topics might not be connected to the rest of the network
-- Other nodes in the network might not subscribe and relay on your given PubSub topic
-- Store nodes might not store messages for your given PubSub topic
-
-This means you are likely to have to run your own full nodes which may make your application less robust.
-
-Below we outline some scenarios where this might apply.
-
-### Separation of two applications example
-
-Let's say we have two different topics that are both experience heavy traffic but are completely separate in terms of problem domain and infrastructure.
-This can be segregated into:
+Larger apps can segregate their pubsub meshes using topics named like:
 
 ```
 /waku/2/status/
 /waku/2/walletconnect/
 ```
 
-This indicates that they are WakuMessages but for different domains completely.
+This indicates that these networks carry WakuMessages, but for different domains completely.
 
-### Topic sharding example
+### Named Topic Sharding Example
 
 The following is an example of named sharding, as specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
 
@@ -101,9 +82,7 @@ waku/2/waku-9_shard-9/
 
 This indicates explicitly that the network traffic has been partitioned into 10 buckets.
 
-Besides named sharding, [51/WAKU2-RELAY-SHARDING](/spec/51) specifies two more sharding methods: static sharding and automatic sharding.
-
-## Content topics
+## Content Topics
 
 The other type of topic that exists in Waku v2 is a content topic.
 This is used for content based filtering.
@@ -118,7 +97,7 @@ and only want to pull down messages that match this given content topic.
 Since all messages are relayed using the relay protocol regardless of content topic,
 you MAY use any content topic you wish without impacting how messages are relayed.
 
-### Content topic format
+### Content Topic Format
 
 The format for content topics is as follows:
 
@@ -129,21 +108,20 @@ As an example, here's the content topic used for an upcoming testnet:
 
 `/toychat/2/huilong/proto`
 
-## Using content topics for your application
+### Content Topic Naming Recommendations
 
-Make sure you have a unique application-name to avoid conflicting issues with other protocols.
-
-If you have different versions of your protocol, this can be specified in the version field.
-
-The name of the content topic is up to your application and depends on the problem domain, how you want to separate content, what the bandwidth and privacy guarantees are, etc.
-
+Application names should be unique to avoid conflicting issues with other protocols.
+Applications should specify their version (if applicable) in the version field.
+The `{content-topic-name}` portion of the content topic is up to the application,
+and depends on the problem domain.
+It can be hierarchical, for instance to separate content, or to indicate different bandwidth and privacy guarantees.
 The encoding field indicates the serialization/encoding scheme for the [WakuMessage payload](/spec/14/#payloads) field.
 
 ## Differences with Waku v1
 
 In [6/WAKU1](/spec/6) there is no actual routing.
 All messages are sent to all other nodes.
-This means that we are implicitly using the same PubSub topic that would be something like:
+This means that we are implicitly using the same pubsub topic that would be something like:
 
 ```
 /waku/1/default-waku/rlp
@@ -180,22 +158,13 @@ Copyright and related rights waived via
 
 # References
 
-1. [10/WAKU2 spec](/spec/10)
-
-2. [11/WAKU2-RELAY](/spec/11)
-
-3. [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages)
-
-4. [14/WAKU2-MESSAGE spec](/spec/14)
-
-5. [12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/)
-
-6. [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/)
-
-7. [6/WAKU1](/spec/6)
-
-8. [15/WAKU-BRIDGE](/spec/15)
-
-9. [26/WAKU-PAYLOAD](/spec/26)
-
-10. [51/WAKU2-RELAY-SHARDING](/spec/51)
+* [10/WAKU2 spec](/spec/10)
+* [11/WAKU2-RELAY](/spec/11)
+* [51/WAKU2-RELAY-SHARDING](/spec/51)
+* [Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages)
+* [14/WAKU2-MESSAGE spec](/spec/14)
+* [12/WAKU2-FILTER](https://rfc.vac.dev/spec/12/)
+* [13/WAKU2-STORE](https://rfc.vac.dev/spec/13/)
+* [6/WAKU1](/spec/6)
+* [15/WAKU-BRIDGE](/spec/15)
+* [26/WAKU-PAYLOAD](/spec/26)

--- a/content/docs/rfcs/23/README.md
+++ b/content/docs/rfcs/23/README.md
@@ -91,7 +91,7 @@ This indicates that they are WakuMessages but for different domains completely.
 
 ### Topic sharding example
 
-The following is an example of named sharing, as specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
+The following is an example of named sharding, as specified in [51/WAKU2-RELAY-SHARDING](/spec/51).
 
 ```
 waku/2/waku-9_shard-0/

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -38,12 +38,9 @@ This document also covers discovery of topic shards.
 It is RECOMMENDED for App protocols to follow the naming structure detailed in [23/WAKU2-TOPICS](/spec/23/).
 With named sharding, managing discovery falls into the responsibility of apps.
 
-The default Waku pubsub topic `/waku/2/default-waku` can be seen as a named shard available to all app protocols.
+The default Waku pubsub topic `/waku/2/default-waku/proto` can be seen as a named shard available to all app protocols.
 
-> *Note*: Future versions of this document are planned to give more guidance with respect to discovery via
-[33/WAKU2-DISCV5](/spec/33/),
-[DNS discovery](https://eips.ethereum.org/EIPS/eip-1459),
-and inter-mesh discovery via gossipsub control messages (also using circuit relay).
+
 
 From an app protocol point of view, a subscription to a content topic `waku2/xxx` on a shard named /mesh/v1.1.1/xxx would look like:
 
@@ -216,6 +213,22 @@ We will add more on security considerations in future versions of this document.
 The strength of receiver anonymity, i.e. topic receiver unlinkablity,
 depends on the number of content topics (`k`) that get mapped onto a single pubsub topic (shard).
 For *named* and *static* sharding this responsibility is at the app protocol layer.
+
+## Default Topic
+
+Until automatic sharding is fully specified, (smaller) Apps SHOULD use the default PubSub topic unless there is a good reason,
+e.g. a requirement to scale to large user numbers (in a rollout phase, the default pubsub topic might still be the better option).
+
+Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
+See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
+
+Using another pubsub topic might lead to
+
+- weaker metadata protection
+- connectivity problems if there are not enough nodes within the respective pubsub mesh
+- store nodes might not store messages for the chosen pubsub topic
+
+Apps that use named (not the default) or static sharding likely have to setup their own infrastructure nodes which may render the application less robust.
 
 # Copyright
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -219,7 +219,7 @@ For *named* and *static* sharding this responsibility is at the app protocol lay
 Until automatic sharding is fully specified, (smaller) Apps SHOULD use the default PubSub topic unless there is a good reason not to,
 e.g. a requirement to scale to large user numbers (in a rollout phase, the default pubsub topic might still be the better option).
 
-Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.
+Using a single PubSub topic ensures a connected network, as well as some degree of metadata protection.
 See [section on Anonymity/Unlinkability](/spec/10/#anonymity--unlinkability).
 
 Using another pubsub topic might lead to

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -35,16 +35,15 @@ This document also covers discovery of topic shards.
 # Named Sharding
 
 *Named sharding* offers apps to freely choose pubsub topic names.
-App protocols SHOULD follow the naming structure detailed in [23/WAKU2-TOPICS](/spec/23/).
+It is RECOMMENDED for App protocols to follow the naming structure detailed in [23/WAKU2-TOPICS](/spec/23/).
 With named sharding, managing discovery falls into the responsibility of apps.
 
-The default Waku pubsub topic `/waku/2/default-waku/proto` can be seen as a named shard available to all app protocols.
+The default Waku pubsub topic `/waku/2/default-waku` can be seen as a named shard available to all app protocols.
 
 > *Note*: Future versions of this document are planned to give more guidance with respect to discovery via
 [33/WAKU2-DISCV5](/spec/33/),
 [DNS discovery](https://eips.ethereum.org/EIPS/eip-1459),
 and inter-mesh discovery via gossipsub control messages (also using circuit relay).
-It might make sense to deprecate [23/WAKU2-TOPICS](/spec/23/) as a separate spec and merge it here.
 
 From an app protocol point of view, a subscription to a content topic `waku2/xxx` on a shard named /mesh/v1.1.1/xxx would look like:
 
@@ -88,15 +87,15 @@ This offers k-anonymity and better connectivity, but comes at a higher bandwidth
 
 The name of the pubsub topic corresponding to a given static shard is specified as
 
-`/waku/2/static-rshard/<shard_cluster_index>/<shard_number>`,
+`/waku/2/rs/<shard_cluster_index>/<shard_number>`,
 
 an example for the 2nd shard in the global shard cluster:
 
-`/waku/2/static-rshard/0/2`.
+`/waku/2/rs/0/2`.
 
 > *Note*: Because *all* shards distribute payload defined in [14/WAKU2-MESSAGE](spec/14/) via [protocol buffers](https://developers.google.com/protocol-buffers/),
 the pubsub topic name does not explicitly add `/proto` to indicate protocol buffer encoding.
-We use `rshard` (as well as `rs` as the ENR key) to indicate these are relay shard clusters; further shard types might follow in the future.
+We use `rs` to indicate these are *relay shard* clusters; further shard types might follow in the future.
 
 From an app point of view, a subscription to a content topic `waku2/xxx` on a static shard would look like:
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -216,7 +216,7 @@ For *named* and *static* sharding this responsibility is at the app protocol lay
 
 ## Default Topic
 
-Until automatic sharding is fully specified, (smaller) Apps SHOULD use the default PubSub topic unless there is a good reason,
+Until automatic sharding is fully specified, (smaller) Apps SHOULD use the default PubSub topic unless there is a good reason not to,
 e.g. a requirement to scale to large user numbers (in a rollout phase, the default pubsub topic might still be the better option).
 
 Using a single PubSub topic ensures a connected network, as well some degree of metadata protection.


### PR DESCRIPTION
## Background

This PR 

* shortens the topic-name part indicating static sharding from `static-rshard` to `rs
* adjusts [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/) to reflect updates made by [51/WAKU2-RELAY-SHARDING](https://rfc.vac.dev/spec/51/).
* removes the superfluous `/{encoding}` part of the pub sub topic name, including removing `/proto` from the default topic.
(Copied from a note added to 23/ with this PR:)

> In previous versions of this document, the default topic was `/waku/2/default-waku/proto`.
The now deprecated `/proto` part indicated that the [data field](/spec/11/#protobuf-definition) in PubSub is serialized/encoded as protobuf.
The inspiration for this format was taken from
[Ethereum 2 P2P spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#topics-and-messages).
However, because the payload of messages transmitted over [11/WAKU2-RELAY](/spec/11) must be a [14/WAKU2-MESSAGE](/spec/14),
which specifies the wire format as protobuf,`/proto` is the only valid encoding.
This makes the `/proto` indication obsolete.
The encoding of the `payload` field of a Waku Message is indicated by the /{encoding} part of the content topic name.
Specifying an encoding is only significant for the actual payload/data field.
Waku preserves this option by allowing to specify an encoding for the WakuMessage payload field as part of the content topic name.

## Open

*  ~~adjust test vectors in [14/WAKU2-MESSAGE](https://rfc.vac.dev/spec/14/) to the updated default topic name~~
*  ~~adjust [36/WAKU2-BINDINGS-API](https://rfc.vac.dev/spec/36/) to the updated default topic name~~
(edit: we will keep the old default topic for backwards compatibility.)

## Future

* Adjust the recommendation in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/) regarding usage of the default topic.
  - give a rough user count threshold estimate where it is worth moving to a sharded setup
  - this will be done after MVP (with insights gained from MVP)
