### PR TITLE
Extend c-bindings with new relay functions, store and discv5 capability

### DIFF
--- a/content/docs/rfcs/36/README.md
+++ b/content/docs/rfcs/36/README.md
@@ -288,8 +288,17 @@ interface JsonConfig {
     nodeKey?: string;
     keepAliveInterval?: number;
     relay?: boolean;
+    relayTopics?: Array<string>;
+    gossipsubParameters?: GossipSubParameters;
     minPeersToPublish?: number
     filter?: boolean;
+    discV5?: boolean;
+    discV5BootstrapNodes?: Array<string>;
+    discV5UDPPort?: number;
+    store?: boolean;
+    databaseURL?: string;
+    storeRetentionMaxMessages?: number;
+    storeRetentionTimeSeconds?: number;
 }
 ```
 
@@ -313,11 +322,27 @@ If a key is `undefined`, or `null`, a default value will be set.
   Default `20`.
 - `relay`: Enable relay protocol.
   Default `true`.
+- `relayTopics`:  Array of pubsub topics that WakuRelay will automatically subscribe to when the node 
+  starts
+  Default `[]`
+- `gossipSubParameters`: custom gossipsub parameters. See `GossipSubParameters` section for defaults
 - `minPeersToPublish`: The minimum number of peers required on a topic to allow broadcasting a message.
   Default `0`.
 - `filter`: Enable filter protocol.
   Default `false`.
-
+- `discV5`: Enable DiscoveryV5.
+  Default `false`
+- `discV5BootstrapNodes`: Array of bootstrap nodes ENR
+- `discV5UDPPort`: UDP port for DiscoveryV5
+  Default `9000`
+- `store`: Enable store protocol to persist message history
+  Default `false`
+- `databaseURL`: url connection string. Accepts SQLite and PostgreSQL connection strings
+  Default: `sqlite3://store.db`
+- `storeRetentionMaxMessages`: max number of messages to store in the database.
+  Default `10000`
+- `storeRetentionTimeSeconds`: max number of seconds that a message will be persisted in the database.
+  Default `2592000` (30d)
 For example:
 ```json
 {
@@ -330,6 +355,108 @@ For example:
   "minPeersToPublish": 0
 }
 ```
+
+
+### `GossipsubParameters` type
+
+Type holding custom gossipsub configuration:
+
+```ts
+interface GossipSubParameters {
+    D?: number;
+    D_low?: number;
+    D_high?: number;
+    D_score?: number;
+    D_out?: number;
+    HistoryLength?: number;
+    HistoryGossip?: number;
+    D_lazy?: number;
+    GossipFactor?: number;
+    GossipRetransmission?: number;
+    HeartbeatInitialDelayMs?: number;
+    HeartbeatIntervalSeconds?: number;
+    SlowHeartbeatWarning?: number;
+    FanoutTTLSeconds?: number;
+    PrunePeers?: number;
+    PruneBackoffSeconds?: number;
+    UnsubscribeBackoffSeconds?: number;
+    Connectors?: number;
+    MaxPendingConnections?: number;
+    ConnectionTimeoutSeconds?: number;
+    DirectConnectTicks?: number;
+    DirectConnectInitialDelaySeconds?: number;
+    OpportunisticGraftTicks?: number;
+    OpportunisticGraftPeers?: number;
+    GraftFloodThresholdSeconds?: number;
+    MaxIHaveLength?: number;
+    MaxIHaveMessages?: number;
+    IWantFollowupTimeSeconds?: number;
+}
+```
+
+Fields: 
+
+All fields are optional.
+If a key is `undefined`, or `null`, a default value will be set.
+
+- `d`: optimal degree for a GossipSub topic mesh. 
+  Default `6`
+- `dLow`: lower bound on the number of peers we keep in a GossipSub topic mesh
+  Default `5`
+- `dHigh`: upper bound on the number of peers we keep in a GossipSub topic mesh.
+  Default `12`
+- `dScore`: affects how peers are selected when pruning a mesh due to over subscription.
+  Default `4`
+- `dOut`: sets the quota for the number of outbound connections to maintain in a topic mesh.
+  Default `2`
+- `historyLength`: controls the size of the message cache used for gossip.
+  Default `5`
+- `historyGossip`: controls how many cached message ids we will advertise in IHAVE gossip messages.
+  Default `3`
+- `dLazy`: affects how many peers we will emit gossip to at each heartbeat.
+  Default `6`
+- `gossipFactor`: affects how many peers we will emit gossip to at each heartbeat.
+  Default `0.25`
+- `gossipRetransmission`: controls how many times we will allow a peer to request the same message id through IWANT gossip before we start ignoring them.
+  Default `3`
+- `heartbeatInitialDelayMs`: short delay in milliseconds before the heartbeat timer begins after the router is initialized.
+  Default `100` milliseconds
+- `heartbeatIntervalSeconds`: controls the time between heartbeats.
+  Default `1` second
+- `slowHeartbeatWarning`: duration threshold for heartbeat processing before emitting a warning.
+  Default `0.1`
+- `fanoutTTLSeconds`: controls how long we keep track of the fanout state.
+  Default `60` seconds
+- `prunePeers`: controls the number of peers to include in prune Peer eXchange.
+  Default `16`
+- `pruneBackoffSeconds`: controls the backoff time for pruned peers.
+  Default `60` seconds
+- `unsubscribeBackoffSeconds`: controls the backoff time to use when unsuscribing from a topic.
+  Default `10` seconds
+- `connectors`: number of active connection attempts for peers obtained through PX.
+  Default `8`
+- `maxPendingConnections`: maximum number of pending connections for peers attempted through px. 
+  Default `128`
+- `connectionTimeoutSeconds`: timeout in seconds for connection attempts.
+  Default `30` seconds
+- `directConnectTicks`: the number of heartbeat ticks for attempting to reconnect direct peers that are not currently connected.
+  Default `300`
+- `directConnectInitialDelaySeconds`: initial delay before opening connections to direct peers.
+  Default `1` second
+- `opportunisticGraftTicks`: number of heartbeat ticks for attempting to improve the mesh with opportunistic grafting.
+  Default `60`
+- `opportunisticGraftPeers`: the number of peers to opportunistically graft.
+  Default `2`
+- `graftFloodThresholdSeconds`: If a GRAFT comes before GraftFloodThresholdSeconds has elapsed since the last PRUNE, then there is an extra score penalty applied to the peer through P7. 
+  Default `10` seconds
+- `maxIHaveLength`: max number of messages to include in an IHAVE message, also controls the max number of IHAVE ids we will accept and request with IWANT from a peer within a heartbeat.
+  Default `5000`
+- `maxIHaveMessages`: max number of IHAVE messages to accept from a peer within a heartbeat.
+  Default `10`
+- `iWantFollowupTimeSeconds`: Time to wait for a message requested through IWANT following an IHAVE advertisement.
+  Default `3` seconds
+- `seenMessagesTTLSeconds`: configures when a previously seen message ID can be forgotten about.
+  Default `120` seconds
 
 ### `extern char* waku_new(char* jsonConfig)`
 
@@ -783,6 +910,22 @@ For example:
 }
 ```
 
+### `extern char* waku_relay_topics()`
+
+Get the list of subscribed pubsub topics in Waku Relay.
+
+**Returns**
+
+A [`JsonResponse`](#jsonresponse-type).
+If the execution is successful, the `result` field will contain an array of pubsub topics.
+
+For example:
+
+```json
+{
+  "result": ["pubsubTopic1", "pubsubTopic2"]
+}
+```
 
 ## Waku Filter
 


### PR DESCRIPTION
I had made a couple of changes to the c-bindings in go-waku that were not included in this RFC.
This PR fixes that

cc: @Ivansete-status (for some reason i can't add you as a reviewer)