### PR TITLE
support level 1 for the table of content

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,3 +8,6 @@ BookMenuBundle = "/menu"
 
 [permalinks]
   docs = "/spec/:slug"
+
+[markup.tableOfContents]
+  startLevel = 1


### PR DESCRIPTION
Support level 1 (single hash #) for table of contents on the right side.

Demo: (Abstract, Motivation, Flow are added)

<img width="1018" alt="Screenshot 2023-05-04 at 4 40 17 PM" src="https://user-images.githubusercontent.com/41753422/236140491-07d7fa46-f138-4047-b974-37de5d2c26a9.png">
