### PR TITLE
feat(51/WAKU2-RELAY-SHARDING): Autosharding update

### DIFF
--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -197,6 +197,30 @@ Example:
 The epoch should be increased when relaying more messages on the shards of the current epoch becomes detrimental.
 Increasing the epoch should require consensus by the Waku community.
 
+## Hashing Floor
+
+This section decribe a way to increase the number of static shards in use. It serves as a temporary solution before auto-sharding.
+
+To compute the shard to use,
+hash the content topic with Sha2-256,
+take the first 14 bits as the index,
+divide by 16384 which is the total range,
+divide again by the number of shards in use then
+floor the result and finally 
+multiply by 16384 divided by number of shards to get the shard index.
+
+Example:
+ - Content hash start with 1101001111110…
+ - The first 14 bits equals to 6782
+ - 16384 divided by 16 shards in use equals 1024
+ - The floor of 6782 divided by 1024 is 6
+ - 6 multiplied by 1024 is 6144, the shard index to use.
+
+To minimize the amount of shard switch when increasing the number, use power of 2 shards in use.
+
+The total shards count in use should be increased when relaying more messages on the current shards becomes detrimental.
+Increasing the total shards should require consensus by the Waku community.
+
 # Automatic Sharding
 
 > *Note:* Automatic sharding is not yet part of this specification.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -215,18 +215,16 @@ For gen0, the shards have priority values; 0.57, -2.18, 1.51, 1.14, 0.65, 0.72, 
 
 ## Content Topics Format for Autosharding
 Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).
-In addition, 2 prefixes MAY be added to content topics.
-Generation & bias.
+In addition, a generation prefix MAY be added to content topics.
 When omitted default values are used.
 Generation default value is `0`.
-Bias default value is `unbiased`.
 
-- The full length format is `/{generation}/{bias}/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
+- The full length format is `/{generation}/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
 - The short length format is `/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
 
 ### Example
 
-- Full length `/0/unbiased/myapp/1/mytopic/cbor`
+- Full length `/0/myapp/1/mytopic/cbor`
 - Short length `/myapp/1/mytopic/cbor`
 
 ### Generation
@@ -238,10 +236,6 @@ The cluster index is 1 and the indices of each shards are numbered 0 to 7.
 This document will be updated for future generations.
 
 <!-- Create a new RFC for generations when this one reach draft or stable status -->
-
-### Bias
-Bias is used to skew the priority of shards via weights.
-Other biases than `unbiased` are unspecified for now but may be used in the future.
 
 ### Topic Design
 Content topics have 2 purposes: filtering and routing.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -279,7 +279,6 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 * [51/WAKU2-RELAY-SHARDING](/spec/51/)
 * [Ethereum ENR sharding bit vector](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#metadata)
 * [Ethereum discv5 specification](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md)
-* [Rendezvous Hashing](https://www.eecs.umich.edu/techreports/cse/96/CSE-TR-316-96.pdf)
 * [Research log: Waku Discovery](https://vac.dev/wakuv2-apd)
 * [45/WAKU2-ADVERSARIAL-MODELS](/spec/45)
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -1,4 +1,4 @@
----
+﻿---
 slug: 51
 title: 51/WAKU2-RELAY-SHARDING
 name: Waku v2 Relay Sharding
@@ -122,7 +122,7 @@ The index list SHOULD be used for nodes that participante in fewer than 64 shard
 the bit vector representation SHOULD be used for nodes participating in 64 or more shards.
 Nodes MUST NOT use both index list (`rs`) and bit vector (`rsv`) in a single ENR.
 ENRs with both `rs` and `rsv` keys SHOULD be ignored.
-Nodes MAY interprete `rs` in such ENRs, but MUST ignore `rsv`.
+Nodes MAY interpret `rs` in such ENRs, but MUST ignore `rsv`.
 
 ### Index List
 
@@ -169,13 +169,13 @@ This example node is part of shards `13`, `14`, and `45` in the Status main-net 
 
 # Automatic Sharding
 
-Autosharding selects shards automatically and is the default behaviour for shard choice.
+Autosharding selects shards automatically and is the default behavior for shard choice.
 The other choices being static and named sharding as seen in previous sections.
-Shards (pubsub topics) MUST be computed from content topics with the procedure below.
+Shards (pubsub topics) SHOULD be computed from content topics with the procedure below.
 
 ## Rendezvous Hashing
 
-Also known as the Highest Random Weight (HRW) method, has many properties useful for shard selection.
+Also known as the Highest Random Weight (H.R.W.) method, has many properties useful for shard selection.
 - Distributed agreement. Local only computation without communication.
 - Load balancing. Content topics are spread as equally as possible to shards.
 - Minimal disruption. Content topics switch shards infrequently.
@@ -185,8 +185,8 @@ Also known as the Highest Random Weight (HRW) method, has many properties useful
 
 For each shard,
 hash using Sha2-256 the concatenation of
-the content topic `application` field (N UTF-8 bytes),
-`version` (N UTF-8 bytes),
+the content topic `application` field (N U.T.F.-8 bytes),
+`version` (N U.T.F.-8 bytes),
 the `cluster` index (2 bytes) and
 the `shard` index (2 bytes)
 take the first 64 bits of the hash,
@@ -195,7 +195,7 @@ compute the natural logarithm of this number then
 take the negative of the weight (default 1.0) divided by it.
 Finally, sort the shard value pairs.
 
-The shard with the highest value MUST be used.
+The shard with the highest value SHOULD be used.
 
 ### Example
 | Field | Value | Hex |
@@ -207,7 +207,7 @@ The shard with the highest value MUST be used.
 
 - SHA2-256 of `0x6d796170703100010006` is `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2`
 - The first 64 bits `0xfdac5fb315b791cc` divided by `0xffffffffffffffff` is ~`0.99`
-- The natual logarithm of `0.99` is ~`-0.01`
+- The natural logarithm of `0.99` is ~`-0.01`
 - `-1` divided by `-0.01` equals ~`99.5`
 - Shard 6 has the priority value 99.5
 
@@ -219,9 +219,13 @@ When omitted default values are used.
 Generation default value is `0`.
 Bias default value is `unbiased`.
 
+- The full length format is `{generation}/{bias}/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
+- The short length format is `/{application-name}/{version-of-the-application}/{content-topic-name}/{encoding}`
+
 ### Example
 
-`/0/unbiased/myapp/1/mysub/cbor`
+- Full length `/0/unbiased/myapp/1/mytopic/cbor`
+- Short length `/myapp/1/mytopic/cbor`
 
 ### Generation
 The generation number monotonously increases and indirectly refers to the total number of shards of the Waku Network.
@@ -229,18 +233,18 @@ The generation number monotonously increases and indirectly refers to the total 
 The first generation (zero) MUST use 8 shards in total.
 The cluster index is 1 and the indices of each shards are numbered 0 to 7.
 
-This document will be updated for future generation.
+This document will be updated for future generations.
 
 ### Bias
 Bias is used to skew the priority of shards via weights.
 Other biases than `unbiased` are unspecified for now but may be used in the future.
 
 ### Topic Design
-Content topics have 2 purposes filtering and routing.
-Filtering is done by changing the `subject` field.
+Content topics have 2 purposes: filtering and routing.
+Filtering is done by changing the `{content-topic-name}` field.
 As this part is not hashed, it will not affect routing (shard selection).
-The `application` and `version` fields do affect routing.
-Using multiple content topics with different `application` field has advantages and disadvantages.
+The `{application-name}` and `{version-of-the-application}` fields do affect routing.
+Using multiple content topics with different `{application-name}` field has advantages and disadvantages.
 It increases the traffic a relay node is subjected to when subscribed to all topics.
 It also allows relay and light nodes to subscribe to a subset of all topics.
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -173,7 +173,7 @@ This example node is part of shards `13`, `14`, and `45` in the Status main-net 
 
 # Automatic Sharding
 
-Autosharding is a method for managing decisions related to shards for small or new apps automatically.
+Autosharding is a method of managing decisions related to shards for small or new apps automatically.
 By sharing shards with peers of other apps, the total set of peers increase which increase anonymity.
 On the other hand, sharing a shard with other apps increase the number of unrelated messages a peer has to relay. 
 Autosharding is the default behaviour but opting out is always possible for apps that want more control.
@@ -185,13 +185,13 @@ From an app point of view, a subscription to a content topic `waku2/xxx` using a
 The app is oblivious to the pubsub topic layer.
 (Future versions could deprecate the default pubsub topic and remove the necessity for `auto=true`.)
 
-The following is a list of possible candidate for autosharding v1
+The following is a list of candidate for autosharding v1
 
 ## Epoch
 
 Content topic must be prefixed with an epoch number. This number must start at 0.
 
-```epoch/0/my_content_topic```
+```/waku2/epoch/0/my_content_topic```
 
 Refer to [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topics) on how to structure your content topics.
 
@@ -230,7 +230,7 @@ Example:
  - The floor of 6782 divided by 1024 is 6
  - 6 multiplied by 1024 is 6144, the shard index to use.
 
-To minimize the amount of shard switch when increasing the number, use power of 2.
+To minimize the amount of shard switch when increasing total shards, use power of 2.
 
 The total shards count in use should be increased when relaying more messages on the current shards becomes detrimental.
 Increasing the total shards should require consensus by the Waku community.
@@ -253,8 +253,9 @@ Example: RNG is seeded with the content topic hash, total shard is 3
  - Next random number is .278
  - This number is smaller than 1 divided by 3
  - New best bet is shard 2
+ - Iteration is done and shard 2 is choosen
 
-This algorithm simple but doesn't take any other parameter.
+This algorithm simple and doesn't take any other parameter.
 
 The total shards count in use should be increased when relaying more messages on the current shards becomes detrimental.
 Increasing the total shards should require consensus by the Waku community.
@@ -277,7 +278,7 @@ Example:
  - Sort the hash values; 0101011100101, 1010101010111, 1111100010111
  - Shard 2 has the biggest hash value
 
-It's possible to pick the second highest value, if for some reason the first is unavailable or even more than one shards. Further more, a weight can be given to shards to modify their resulting hash values. 
+It's possible to pick the second highest value, if for some reason the first is unavailable or even more than one shards. Further more, a weight can be given to shards to modify their chances. 
 
 See [research paper](https://www.eecs.umich.edu/techreports/cse/96/CSE-TR-316-96.pdf) for more.
 
@@ -287,9 +288,6 @@ See [research paper](https://www.eecs.umich.edu/techreports/cse/96/CSE-TR-316-96
 
 Hot spots occur (similar to DHTs), when a specific mesh network (shard) becomes responsible for (several) large multicast groups (content topics).
 The opposite problem occurs when a mesh only carries multicast groups with very few participants: this might cause bad connectivity within the mesh.
-
-If a node is part of many content topics which are all spread over different shards,
-the node will potentially be exposed to a lot of network traffic.
 
 None of the proposed autsharding methods can solve this problem.
 
@@ -330,7 +328,7 @@ We will add more on security considerations in future versions of this document.
 ## Receiver Anonymity
 
 The strength of receiver anonymity, i.e. topic receiver unlinkablity,
-depends on the number of content topics (`k`) that get mapped onto a single pubsub topic (shard).
+depends on the number of content topics (`k`), as a proxy for the number of peers and messages, that get mapped onto a single pubsub topic (shard).
 For *named* and *static* sharding this responsibility is at the app protocol layer.
 
 ## Default Topic

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -211,7 +211,8 @@ The shard with the highest value SHOULD be used.
 - `-1` divided by `-0.01` equals ~`100`
 - Shard 6 has the priority value 100
 
-For gen0, the shards have priority values; 0.57, -2.18, 1.51, 1.14, 0.65, 0.72, 100, 0.54, content topic `/myapp/1/myname/cbor` should use shard 6
+With the same method, the other priority values would be; 0.57, -2.18, 1.51, 1.14, 0.65, 0.72, 0.54
+Content topic `/myapp/1/myname/cbor` should use shard 6 because it has the highest value.
 
 ## Content Topics Format for Autosharding
 Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -53,7 +53,7 @@ Static shards are managed in shard clusters of 1024 shards per cluster.
 Waku static sharding can manage $2^16$ shard clusters.
 Each shard cluster is identified by its index (between $0$ and $2^16-1$).
 
-A specific shard cluster is either globally available to all apps (like the default pubsub topic),
+A specific shard cluster is either globally available to all apps,
 specific for an app protocol,
 or reserved for automatic sharding (see next section).
 
@@ -169,10 +169,8 @@ This example node is part of shards `13`, `14`, and `45` in the Status main-net 
 
 # Automatic Sharding
 
-Autosharding is a method of managing decisions related to shards automatically.
-By sharing shards with peers of other apps, the total set of peers increase which increase anonymity.
-On the other hand, sharing a shard with other apps increase the number of unrelated messages a peer has to relay. 
-Autosharding is the default behaviour for shard choice but opting out is always possible for apps that want more control.
+Autosharding select shards automatically and is the default behaviour for shard choice but opting out is always possible.
+Shards (pubsub topics) not longer have to be chosen, they are instead computed from content topics with the procedure below.
 
 ## Rendezvous Hashing
 
@@ -182,10 +180,16 @@ Also known as the Highest Random Weight (HRW) method, has many properties useful
 - Minimal disruption. Content topics switch shards infrequently.
 - Low overhead. Easy to compute.
 
+### Algorithm
+
 For each shard,
-hash using Sha2-256 the concatenation of the content topic application (N bytes), version (N bytes), the cluster index (2 bytes) and the shard index (2 bytes)
+hash using Sha2-256 the concatenation of
+the content topic application field (N UTF-8 bytes),
+version (N UTF-8 bytes),
+the cluster index (2 bytes) and
+the shard index (2 bytes)
 take the first 64 bits of the hash,
-divide the hash value by 2^64,
+divided by 2^64,
 compute the natural logarithm of this number then
 take the negative of the weight (default 1.0) divided by it.
 Finally, sort the values and pick the shard with the highest one.
@@ -197,12 +201,13 @@ So that apps can manipulate the shard selection, 2 prefixes CAN be added to cont
 - Long format `/generation/bias/application/version/subject/encoding`
 
 ### Generation
-This number indirectly refer to the total number of shards of the Waku network. It start at 0 and monotonously increase.
-The first generation (zero) use ?TODO? shards in total.
-
-Community consensus should be reach before increasing the generation and shards in the network as it would affect everyone.
+Monotonously increase and indirectly refer to the total number of shards of the Waku network. 
 
 Default: `0`
+
+The first generation (zero) use ?TODO? shards in total. This document will be updated with future generation shard numbers.
+
+Community consensus should be reach before increasing the generation and shards in the network as it would affect everyone.
 
 ### Bias
 Bias is used to skew the priority of shards via weights. Unspecified for now but may be used in the future.
@@ -271,7 +276,6 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 * [51/WAKU2-RELAY-SHARDING](/spec/51/)
 * [Ethereum ENR sharding bit vector](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#metadata)
 * [Ethereum discv5 specification](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-theory.md)
-* [Jump Consistent hashing](https://arxiv.org/pdf/1406.2294.pdf)
 * [Rendezvous Hashing](https://www.eecs.umich.edu/techreports/cse/96/CSE-TR-316-96.pdf)
 * [Research log: Waku Discovery](https://vac.dev/wakuv2-apd)
 * [45/WAKU2-ADVERSARIAL-MODELS](/spec/45)

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -237,6 +237,8 @@ The cluster index is 1 and the indices of each shards are numbered 0 to 7.
 
 This document will be updated for future generations.
 
+<!-- Create a new RFC for generations when this one reach draft or stable status -->
+
 ### Bias
 Bias is used to skew the priority of shards via weights.
 Other biases than `unbiased` are unspecified for now but may be used in the future.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -173,46 +173,27 @@ Autosharding selects shards automatically and is the default behavior for shard 
 The other choices being static and named sharding as seen in previous sections.
 Shards (pubsub topics) SHOULD be computed from content topics with the procedure below.
 
-## Rendezvous Hashing
-
-Also known as the Highest Random Weight (H.R.W.) method, has many properties useful for shard selection.
-- Local only computation without communication.
-- Content topics are spread as equally as possible to shards.
-- Content topics switch shards infrequently.
-- Easy to compute.
-
 ### Algorithm
 
-For each shard,
-hash using Sha2-256 the concatenation of
+Hash using Sha2-256 the concatenation of
 the content topic `application` field (UTF-8 string of N bytes),
 `version` (UTF-8 string of N bytes),
 the `cluster` index (2 bytes) and
 the `shard` index (2 bytes)
-take the first 64 bits of the hash,
-divided by 2^64-1,
-compute the natural logarithm of this number then
-take the negative of the weight (default 1.0) divided by it.
-Finally, sort the shard value pairs.
-
-The shard with the highest value SHOULD be used.
+bitwise AND by the number of shards in the network minus 1,
 
 ### Example
-| Field | Value | Hex |
-|---    |---    |---  |
-| `application`| "myapp"| 0x6d79617070|
-| `version`    | "1"    | 0x31
-| `cluster`    | 1      | 0x0001
-| `shard`      | 6      | 0x0006
+| Field           | Value  | Hex 
+|---              |---     |---          
+| `application`   | "myapp"| 0x6d79617070
+| `version`       | "1"    | 0x31
+| `cluster`       | 1      | 0x0001
+| `shard`         | 6      | 0x0006
+| `network shards`| 8      | 0x8
 
 - SHA2-256 of `0x6d796170703100010006` is `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2`
-- The first 64 bits `0xfdac5fb315b791cc` divided by `0xffffffffffffffff` is ~`0.99`
-- The natural logarithm of `0.99` is ~`-0.01`
-- `-1` divided by `-0.01` equals ~`100`
-- Shard 6 has the priority value 100
-
-With the same method, the other priority values would be; 0.57, -2.18, 1.51, 1.14, 0.65, 0.72, 0.54
-Content topic `/myapp/1/myname/cbor` should use shard 6 because it has the highest value.
+- `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2` AND `7`(8-1) equals `2`
+- The shard to use has index 2
 
 ## Content Topics Format for Autosharding
 Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -230,12 +230,7 @@ Generation default value is `0`.
 ### Generation
 The generation number monotonously increases and indirectly refers to the total number of shards of the Waku Network.
 
-The first generation (zero) MUST use 8 shards in total.
-The cluster index is 1 and the indices of each shards are numbered 0 to 7.
-
-This document will be updated for future generations.
-
-<!-- Create a new RFC for generations when this one reach draft or stable status -->
+<!-- Create a new RFC for each generation spec. -->
 
 ### Topic Design
 Content topics have 2 purposes: filtering and routing.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -169,7 +169,7 @@ This example node is part of shards `13`, `14`, and `45` in the Status main-net 
 
 # Automatic Sharding
 
-Autosharding select shards automatically and is the default behaviour for shard choice.
+Autosharding selects shards automatically and is the default behaviour for shard choice.
 The other choices being static and named sharding as seen in previous sections.
 Shards (pubsub topics) MUST be computed from content topics with the procedure below.
 
@@ -211,7 +211,7 @@ The shard with the highest value MUST be used.
 - `-1` divided by `-0.01` equals ~`99.5`
 - Shard 6 has the priority value 99.5
 
-## Content Topics Format For Autosharding
+## Content Topics Format for Autosharding
 Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).
 In addition, 2 prefixes MAY be added to content topics.
 Generation & bias.
@@ -224,7 +224,7 @@ Bias default value is `unbiased`.
 `/0/unbiased/myapp/1/mysub/cbor`
 
 ### Generation
-The generation number monotonously increase and indirectly refer to the total number of shards of the Waku network.
+The generation number monotonously increases and indirectly refers to the total number of shards of the Waku Network.
 
 The first generation (zero) MUST use 8 shards in total.
 The cluster index is 1 and the indices of each shards are numbered 0 to 7.
@@ -241,12 +241,12 @@ Filtering is done by changing the `subject` field.
 As this part is not hashed, it will not affect routing (shard selection).
 The `application` and `version` fields do affect routing.
 Using multiple content topics with different `application` field has advantages and disadvantages.
-It increase the traffic a relay node is subjected to when subscribed to all topics.
-It also allow relay and light nodes to subscribe to a subset of all topics.
+It increases the traffic a relay node is subjected to when subscribed to all topics.
+It also allows relay and light nodes to subscribe to a subset of all topics.
 
 ## Problems
 
-### Hotspots
+### Hot Spots
 
 Hot spots occur (similar to DHTs), when a specific mesh network (shard) becomes responsible for (several) large multicast groups (content topics).
 The opposite problem occurs when a mesh only carries multicast groups with very few participants: this might cause bad connectivity within the mesh.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -169,8 +169,9 @@ This example node is part of shards `13`, `14`, and `45` in the Status main-net 
 
 # Automatic Sharding
 
-Autosharding select shards automatically and is the default behaviour for shard choice but opting out is always possible.
-Shards (pubsub topics) not longer have to be chosen, they are instead computed from content topics with the procedure below.
+Autosharding select shards automatically and is the default behaviour for shard choice.
+The other choices being static and named sharding as seen in previous sections.
+Shards (pubsub topics) MUST be computed from content topics with the procedure below.
 
 ## Rendezvous Hashing
 
@@ -186,44 +187,62 @@ For each shard,
 hash using Sha2-256 the concatenation of
 the content topic `application` field (N UTF-8 bytes),
 `version` (N UTF-8 bytes),
-the cluster index (2 bytes) and
-the shard index (2 bytes)
+the `cluster` index (2 bytes) and
+the `shard` index (2 bytes)
 take the first 64 bits of the hash,
 divided by 2^64,
 compute the natural logarithm of this number then
 take the negative of the weight (default 1.0) divided by it.
-Finally, sort the values and pick the shard with the highest one.
+Finally, sort the shard value pairs.
 
-## Content Topic Prefixes
-So that apps can manipulate the shard selection, 2 prefixes CAN be added to content topics.
+The shard with the highest value MUST be used.
+
+### Example
+| Field | Value | Hex |
+|---    |---    |---  |
+| `application`| "myapp"| 0x6d79617070|
+| `version`    | "1"    | 0x31
+| `cluster`    | 1      | 0x0001
+| `shard`      | 6      | 0x0006
+
+- SHA2-256 of `0x6d796170703100010006` is `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2`
+- The first 64 bits `0xfdac5fb315b791cc` divided by `0xffffffffffffffff` is ~`0.99`
+- The natual logarithm of `0.99` is ~`-0.01`
+- `-1` divided by `-0.01` equals ~`99.5`
+- Shard 6 has the priority value 99.5
+
+## Content Topics Format For Autosharding
+Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).
+In addition, 2 prefixes MAY be added to content topics.
 Generation & bias.
 When omitted default values are used.
+Generation default value is `0`.
+Bias default value is `unbiased`.
 
-- Short format `/application/version/subject/encoding`
-- Long format `/generation/bias/application/version/subject/encoding`
+### Example
 
-### Topic design
-Content topics have 2 purposes filtering and routing.
-Filtering is done by changing the `subject` field as this part is not hashed, it will not affect routing (shard selection).
-The `application` and `version` fields do affect routing.
-Application designer should understand that using different `application` field has a cost.
-It increase the traffic a node has to relay when subscribed to all topics but can benefit nodes that only use a subset of topics.
+`/0/unbiased/myapp/1/mysub/cbor`
 
 ### Generation
-Monotonously increase and indirectly refer to the total number of shards of the Waku network. 
+The generation number monotonously increase and indirectly refer to the total number of shards of the Waku network.
 
-Default: `0`
+The first generation (zero) MUST use 8 shards in total.
+The cluster index is 1 and the indices of each shards are numbered 0 to 7.
 
-The first generation (zero) use 8 shards in total.
-This document will be updated with future generation shard numbers.
-
-Community consensus should be reach before increasing the generation and shards in the network as it would affect everyone.
+This document will be updated for future generation.
 
 ### Bias
 Bias is used to skew the priority of shards via weights.
-Unspecified for now but may be used in the future.
+Other biases than `unbiased` are unspecified for now but may be used in the future.
 
-Default: `unbiased`
+### Topic Design
+Content topics have 2 purposes filtering and routing.
+Filtering is done by changing the `subject` field.
+As this part is not hashed, it will not affect routing (shard selection).
+The `application` and `version` fields do affect routing.
+Using multiple content topics with different `application` field has advantages and disadvantages.
+It increase the traffic a relay node is subjected to when subscribed to all topics.
+It also allow relay and light nodes to subscribe to a subset of all topics.
 
 ## Problems
 
@@ -232,9 +251,9 @@ Default: `unbiased`
 Hot spots occur (similar to DHTs), when a specific mesh network (shard) becomes responsible for (several) large multicast groups (content topics).
 The opposite problem occurs when a mesh only carries multicast groups with very few participants: this might cause bad connectivity within the mesh.
 
-The current autosharding methods cannot solve this problem.
+The current autosharding method cannot solve this problem.
 
-A new version of autosharding based on network traffic mesurements could be designed to migrate content topics from shards to shards but would require further research and development.
+A new version of autosharding based on network traffic measurements could be designed but would require further research and development.
 
 ### Discovery
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -184,8 +184,8 @@ Also known as the Highest Random Weight (HRW) method, has many properties useful
 
 For each shard,
 hash using Sha2-256 the concatenation of
-the content topic application field (N UTF-8 bytes),
-version (N UTF-8 bytes),
+the content topic `application` field (N UTF-8 bytes),
+`version` (N UTF-8 bytes),
 the cluster index (2 bytes) and
 the shard index (2 bytes)
 take the first 64 bits of the hash,
@@ -195,22 +195,33 @@ take the negative of the weight (default 1.0) divided by it.
 Finally, sort the values and pick the shard with the highest one.
 
 ## Content Topic Prefixes
-So that apps can manipulate the shard selection, 2 prefixes CAN be added to content topics. Generation & bias. When omitted default values are used.
+So that apps can manipulate the shard selection, 2 prefixes CAN be added to content topics.
+Generation & bias.
+When omitted default values are used.
 
 - Short format `/application/version/subject/encoding`
 - Long format `/generation/bias/application/version/subject/encoding`
+
+### Topic design
+Content topics have 2 purposes filtering and routing.
+Filtering is done by changing the `subject` field as this part is not hashed, it will not affect routing (shard selection).
+The `application` and `version` fields do affect routing.
+Application designer should understand that using different `application` field has a cost.
+It increase the traffic a node has to relay when subscribed to all topics but can benefit nodes that only use a subset of topics.
 
 ### Generation
 Monotonously increase and indirectly refer to the total number of shards of the Waku network. 
 
 Default: `0`
 
-The first generation (zero) use ?TODO? shards in total. This document will be updated with future generation shard numbers.
+The first generation (zero) use 8 shards in total.
+This document will be updated with future generation shard numbers.
 
 Community consensus should be reach before increasing the generation and shards in the network as it would affect everyone.
 
 ### Bias
-Bias is used to skew the priority of shards via weights. Unspecified for now but may be used in the future.
+Bias is used to skew the priority of shards via weights.
+Unspecified for now but may be used in the future.
 
 Default: `unbiased`
 

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -178,17 +178,17 @@ Shards (pubsub topics) SHOULD be computed from content topics with the procedure
 Hash using Sha2-256 the concatenation of
 the content topic `application` field (UTF-8 string of N bytes) and
 the `version` (UTF-8 string of N bytes).
-The shard to use is the bitwise AND of the hash by the number of shards in the network minus 1,
+The shard to use is the modulo of the hash by the number of shards in the network.
 
 ### Example
 | Field           | Value  | Hex 
 |---              |---     |---          
 | `application`   | "myapp"| 0x6d79617070
 | `version`       | "1"    | 0x31
-| `network shards`| "8"    | 0x8
+| `network shards`|   8    | 0x8
 
-- SHA2-256 of `0x6d7961707031` is `8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928`
-- `8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928` AND `7`(8-1) equals `0`
+- SHA2-256 of `0x6d7961707031` is `0x8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928`
+- `0x8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928` MOD `8` equals `0`
 - The shard to use has index 0
 
 ## Content Topics Format for Autosharding

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -171,6 +171,32 @@ The `[...]` in the example indicates 120 `0` bytes.
 This example node is part of shards `13`, `14`, and `45` in the Status main-net shard cluster (index 16).
 (This is just for illustration purposes, a node that is only part of three shards should use the index list method specified above.)
 
+## Epoch
+
+This section decribe a way to increase the number of static shards in use. It serves as a temporary solution before auto-sharding.
+
+Content topic must be prefixed with an epoch number. This number must start at 0.
+
+```epoch/0/my_content_topic```
+
+Refer to [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topics) on how to structure your content topics.
+
+To compute the shard index,
+hash the content topic with SHA2-256 omiting the prefix then
+sum all previous epoch numbers,
+skip this number of bits in the hash then
+use the current epoch number of bits as your shard index.
+Offset your shard index by 49151 plus 2 exponent sum of all previous epoch.
+
+Example:
+- epoch 0 would map ALL content topic to shard 49152
+- epoch 1 would map to shard 49153 or 49154 based on the first bit of the content topic hash
+- epoch 2 would map to 49155-49159 based on bits 2 & 3 of the hash
+- epoch 3 would map to 49160-49168 based on bits 4-6 of the hash
+
+The epoch should be increased when relaying more messages on the shards of the current epoch becomes detrimental.
+Increasing the epoch should require consensus by the Waku community.
+
 # Automatic Sharding
 
 > *Note:* Automatic sharding is not yet part of this specification.

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -176,24 +176,20 @@ Shards (pubsub topics) SHOULD be computed from content topics with the procedure
 ### Algorithm
 
 Hash using Sha2-256 the concatenation of
-the content topic `application` field (UTF-8 string of N bytes),
-`version` (UTF-8 string of N bytes),
-the `cluster` index (2 bytes) and
-the `shard` index (2 bytes)
-bitwise AND by the number of shards in the network minus 1,
+the content topic `application` field (UTF-8 string of N bytes) and
+the `version` (UTF-8 string of N bytes).
+The shard to use is the bitwise AND of the hash by the number of shards in the network minus 1,
 
 ### Example
 | Field           | Value  | Hex 
 |---              |---     |---          
 | `application`   | "myapp"| 0x6d79617070
 | `version`       | "1"    | 0x31
-| `cluster`       | 1      | 0x0001
-| `shard`         | 6      | 0x0006
-| `network shards`| 8      | 0x8
+| `network shards`| "8"    | 0x8
 
-- SHA2-256 of `0x6d796170703100010006` is `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2`
-- `0xfdac5fb315b791cca3ccde738ebb0b8d2742519fce1086f2a3d2409cb22a7dd2` AND `7`(8-1) equals `2`
-- The shard to use has index 2
+- SHA2-256 of `0x6d7961707031` is `8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928`
+- `8e541178adbd8126068c47be6a221d77d64837221893a8e4e53139fb802d4928` AND `7`(8-1) equals `0`
+- The shard to use has index 0
 
 ## Content Topics Format for Autosharding
 Content topics MUST follow the format in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/#content-topic-format).

--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -6,7 +6,8 @@ status: raw
 category: Standards Track
 tags:
 editor: Daniel Kaiser <danielkaiser@status.im>
-contributors: Simon-Pierre Vivier <simvivier@status.im>
+contributors:
+- Simon-Pierre Vivier <simvivier@status.im>
 ---
 
 # Abstract


### PR DESCRIPTION
The end result is a design that integrate well with the current specs. It doesn't try to do many thing. It basically pick a random shard per app. Picking a random shard IMO is the best we can do for now.

Generations spec. and shard allocations are out of scope. Each generations specification will have a RFC and modifying shard allocation is something we are considering.

---
*old stuff*

Hello,

Opening this PR as a conversation starter on the topic of automatic sharding (scaling) the Waku network.
I had discussions on the topic already with @kaiserd and @alrevuelta 

There are problems with every path we could take form here.

- No nothing. Free for all, apps pick the shards they want. There is no Waku network...
- Use consistent hashing. These methods can only assign topics to shards evenly. Apps will want their topics on the same shards otherwise the overhead will be massive. Also, it does not distribute traffic, except if we step in as a central authority and start regulating (more like advising since we can't enforce anything).
- Design a new system. Is it even possible? If yes, do we want to spend time (multiple years IMO) on this endeavor?

Discovery: We have no solution, Discv5 is not built for a network with many different apps/protocol/capabilities (yet).

My own [notes](https://rose-dolomite-e17.notion.site/Autosharding-d673780b916e4f479ad1840076309150?pvs=4)