### PR TITLE
Use cluster-id consistently

### DIFF
--- a/content/docs/rfcs/51/README.md
+++ b/content/docs/rfcs/51/README.md
@@ -77,7 +77,7 @@ This offers k-anonymity and better connectivity, but comes at a higher bandwidth
 
 The name of the pubsub topic corresponding to a given static shard is specified as
 
-`/waku/2/rs/<shard_cluster_index>/<shard_number>`,
+`/waku/2/rs/<cluster_id>/<shard_number>`,
 
 an example for the 2nd shard in the global shard cluster:
 

--- a/content/docs/rfcs/57/README.md
+++ b/content/docs/rfcs/57/README.md
@@ -70,7 +70,7 @@ The 1024 shards within the main Status shard cluster are allocated as follows.
 
 Shard indices are mapped to pubsub topic names as follows (specified in [51/WAKU2-RELAY-SHARDING](/spec/51/)).
 
-`/waku/2/rs/<shard_cluster_index>/<shard_number>`
+`/waku/2/rs/<cluster_id>/<shard_number>`
 
 an example for the shard with index `18` in the Status shard cluster:
 

--- a/content/docs/rfcs/64/README.md
+++ b/content/docs/rfcs/64/README.md
@@ -33,7 +33,7 @@ which in turn is an extension of [11/WAKU2-RELAY](https://rfc.vac.dev/spec/11/) 
 Traffic in the Waku Network is sharded into eight [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/) pubsub topics.
 Each pubsub topic is named according to the static shard naming format
 defined in [51/WAKU2-RELAY-SHARDING](https://rfc.vac.dev/spec/51/)
-with `<shard_cluster_index>` set to `1` and
+with `<cluster_id>` set to `1` and
 `<shard_number>` occupying the range `0` to `7`.
 In other words, the Waku Network is a [17/WAKU2-RLN-RELAY](https://rfc.vac.dev/spec/17/) network
 routed on the combination of the eight pubsub topics:


### PR DESCRIPTION
Use cluster-id consistently