### PR TITLE
feat(67/status-waku2-usage): status usage of wakuv2

### DIFF
--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -35,14 +35,18 @@ it is imperative to describe how each are used.
 
 | Terminology  | Description |
 | --------------- | --------- |
-| Waku node | A server running Waku software configured with a set of protocols |
 | `RELAY`| This refers to the Waku Relay protocol, described in [11/WAKU2-RELAY](/spec/11) |
 |`FILTER` | This refers to the Waku Filter protocol, described in [12/WAKU2-FILTER](/spec/12) |
 | `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
-| `Pubsub Topic / Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
-| Light Client | Status clients that operate within resource constrained environments, and uses only a subset of Waku Protocols. |
-| LIGHTPUSH | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
+| `Pubsub Topic` / `Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
+| `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
+
+# Semantics
+Waku Node : A server running Waku software configured with a set of protocols
+
+Light Client: Status clients that operate within resource constrained environments, and uses only a subset of Waku Protocols.
+
 
 # Protocol Usage
 
@@ -51,10 +55,10 @@ The following is a list of Waku Protocols used by the Status application.
 
 ## 1. `RELAY`
 
-> Note: This protocol MUST not supported by Status light clients.
+> Note: This protocol MUST not be used by Status light clients.
 
 Waku Relay is used to broadcast messages from a Status Client.
-All Status messages are transformed into Waku Messages which are sent over the wire.
+All Status messages are transformed into Waku Messages, [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
 All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
 
 Status Clients MUST transform the following object into a `MESSAGE` as described below -

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -24,7 +24,7 @@ Waku, which is described in [10/WAKU2](/spec/10).
 
 The Status application aspires to achieve censorship resistance and incorporates specific privacy features, 
 leveraging the comprehensive set of protocols offered by Waku to enhance these attributes. 
-Waku protocols provide secure communication capbailites over decentralized networks. 
+Waku protocols provide secure communication capabilities over decentralized networks. 
 Once integrated, an application will benifit from privacy preserving, 
 censorship resistance and spam protected communcation. 
 

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -4,9 +4,10 @@ title: 67/STATUS-WAKU2-USAGE
 name: Status Waku2 Usage
 status: raw
 category: Standards Track
-tags: an optional list of tags, not standard
-editor: Jimmy Debe <jimmyyy@status.im>
-contributors: Aaryamann Challani <aaryamann@status.im>
+description: Get familiar with all the Waku protocols used by the Status application.
+editor: Jimmy Debe <jimmy@status.im>
+contributors: 
+- Aaryamann Challani <aaryamann@status.im>
 
 ---
 
@@ -22,30 +23,26 @@ Waku, which is described in [10/WAKU2](/spec/10).
 # Background 
 
 The Status application aspires to achieve censorship resistance and incorporates specific privacy features, 
-leveraging the comprehensive set of protocols offered by Waku to enhance these attributes.
+leveraging the comprehensive set of protocols offered by Waku to enhance these attributes. 
+Waku protocols provide secure communication capbailites over decentralized networks. 
+Once integrated, an application will benifit from privacy preserving, 
+censorship resistance and spam protected communcation. 
 
 Since Status uses a large set of Waku protocols, 
 it is imperative to describe how each are used. 
 
-# Theory / Semantics
+# Definitions
 
-- `Waku node`: A server running Waku software, 
-configured with a set of protocols
-- `RELAY`: This refers to the Waku Relay protocol, 
-described in [11/WAKU2-RELAY](/spec/11)
-- `FILTER`: This refers to the Waku Filter protocol, 
-described in [12/WAKU2-FILTER](/spec/12)
-- `STORE`: This refers to the Waku Store protocol, 
-described in [13/WAKU2-STORE](/spec/13)
-- `MESSAGE`: This refers to the Waku Message format, 
-described in [14/WAKU2-MESSAGE](/spec/14)
-- `Pubsub Topic / Content Topic`: This refers to the routing of messages within the Waku network, 
-described in [23/WAKU2-TOPICS]
-- `Light Client`: This refers to the capabilities of a Status Client, 
-which operates within resource constrained environments,
-and uses only a subset of Waku Protocols.
-- `LIGHTPUSH`: This refers to the Waku Lightpush protocol,
-described in [19/WAKU2-LIGHTPUSH](/spec/19)
+| Terminology  | Description |
+| --------------- | --------- |
+| Waku node | A server running Waku software configured with a set of protocols |
+| `RELAY`| This refers to the Waku Relay protocol, described in [11/WAKU2-RELAY](/spec/11) |
+|`FILTER` | This refers to the Waku Filter protocol, described in [12/WAKU2-FILTER](/spec/12) |
+| `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
+| `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
+| `Pubsub Topic / Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
+| Light Client | Status clients that operate within resource constrained environments, and uses only a subset of Waku Protocols. |
+| LIGHTPUSH | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
 
 # Protocol Usage
 

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -1,0 +1,181 @@
+---
+slug: 67
+title: 67/STATUS-WAKU2-USAGE
+name: Status Waku2 Usage
+status: raw
+category: Standards Track
+tags: an optional list of tags, not standard
+editor: Jimmy Debe <jimmyyy@status.im>
+contributors: Aaryamann Challani <aaryamann@status.im>
+
+---
+
+# Abstract
+
+Status is a chat application which has several features, including, but not limited to -
+- Private 1:1 chats, described by [55/STATUS-1TO1-CHAT](/spec/55)
+- Large scale group chats, described by [56/STATUS-COMMUNITIES](/spec/56)
+
+This specification describes how a Status implementation will make use of the underlying infrastructure, 
+Waku, which is described in [10/WAKU2](/spec/10).
+
+# Background 
+
+The Status application aspires to achieve censorship resistance and incorporates specific privacy features, 
+leveraging the comprehensive set of protocols offered by Waku to enhance these attributes.
+
+Since Status uses a large set of Waku protocols, 
+it is imperative to describe how each are used. 
+
+# Theory / Semantics
+
+- `Waku node`: A server running Waku software, 
+configured with a set of protocols
+- `RELAY`: This refers to the Waku Relay protocol, 
+described in [11/WAKU2-RELAY](/spec/11)
+- `FILTER`: This refers to the Waku Filter protocol, 
+described in [12/WAKU2-FILTER](/spec/12)
+- `STORE`: This refers to the Waku Store protocol, 
+described in [13/WAKU2-STORE](/spec/13)
+- `MESSAGE`: This refers to the Waku Message format, 
+described in [14/WAKU2-MESSAGE](/spec/14)
+- `Pubsub Topic / Content Topic`: This refers to the routing of messages within the Waku network, 
+described in [23/WAKU2-TOPICS]
+- `Light Client`: This refers to the capabilities of a Status Client, 
+which operates within resource constrained environments,
+and uses only a subset of Waku Protocols.
+- `LIGHTPUSH`: This refers to the Waku Lightpush protocol,
+described in [19/WAKU2-LIGHTPUSH](/spec/19)
+
+# Protocol Usage
+
+The following is a list of Waku Protocols used by the Status application.
+
+
+## 1. `RELAY`
+
+> Note: This protocol MUST not supported by Status light clients.
+
+Waku Relay is used to broadcast messages from a Status Client.
+All Status messages are transformed into Waku Messages which are sent over the wire.
+All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
+
+Status Clients MUST transform the following object into a `MESSAGE` as described below -
+
+```go
+StatusSendMessage {
+	SymKey[]     []byte // [optional] The symmetric key used to encrypt the message
+	PublicKey    []byte // [optional] The public key to use for asymmetric encryption
+	Sig          string // [optional] The private key used to sign the message
+	PubsubTopic  string // The Pubsub topic to publish the message to     
+	ContentTopic string // The Content topic to publish the message to
+	Payload      []byte // A serialized representation of a Status message to be sent
+	Padding      []byte // Padding that must be applied to the Payload
+	TargetPeer   string // [optional] The target recipient of the message
+	Ephemeral    bool   // If the message is not to be stored, this is set to `true` 
+}
+```
+
+1. A user MUST only provide either a Symmetric key OR an Asymmetric keypair to encrypt the message.
+If both are received, the implementation MUST throw an error.
+2. `WakuMessage.Payload` MUST be set to `StatusMessage.Payload` 
+3. `WakuMessage.Key` MUST be set to `StatusMessage.SymKey`
+<!-- 
+Curious about the key that is being set within the message here -
+https://github.com/status-im/status-go/blob/dc6fe5613a0b59249b11d14477f581ed636a8153/wakuv2/api.go#L217-L219
+are we sharing the symmetric key for each message?
+-->
+4. `WakuMessage.Version` MUST be set to `1`
+5. `WakuMessage.Ephemeral` MUST be set to `StatusMessage.Ephemeral`
+6. `WakuMessage.ContentTopic` MUST be set to `StatusMessage.ContentTopic`
+7. `WakuMessage.Timestamp` MUST be set to the current Unix epoch timestamp (in nanosecond precision)
+
+## 2. `STORE`
+
+> Note: This protocol MUST remain optional according to the user's preferences,
+it MAY be enabled on Light clients as well.
+
+Messages received via Waku Relay, are stored in a database as described in [13/WAKU2-STORE](/spec/13).
+The messages that have the `ephemeral` flag set to true will not be stored.
+
+The Status Client SHOULD provide a method to prune the database of older records to save storage.
+
+## 3. `FILTER`
+
+> Note: This protocol SHOULD be enabled on Light clients.
+
+This protocol SHOULD be used to filter messages based on a given criteria, such as the Content Topic of a Waku Message.
+
+This allows a reduction in bandwidth consumption by the Status Client.
+
+Status Clients SHOULD apply a filter for all the Content Topics they are interested in, 
+such as Content Topics derived from -
+1. 1:1 chats with other users, described in [55/STATUS-1TO1-CHAT](/spec/55)
+2. Group chats
+3. Community Channels, described in [56/STATUS-COMMUNITIES](/spec/56)
+
+## 4. `LIGHTPUSH`
+
+> Note: This protocol MUST be enabled solely on Light clients.
+
+This protocol allows Status Light Clients to publish messages to the Waku Network,
+without running a full-fledged Waku Relay protocol.
+
+When a Status Client is publishing a message, 
+it MUST check if Light mode is enabled,
+and if so, it MUST publish the message via `LIGHTPUSH`.
+
+## 5. `DISCOVERY`
+
+> Note: This protocol MUST be supported by Light clients and Full clients
+
+Status Clients SHOULD make use of the following peer discovery methods that are provided by Waku,
+such as -
+
+1. [EIP-1459: DNS-Based Discovery](https://eips.ethereum.org/EIPS/eip-1459)
+2. [33/WAKU2-DISCV5](/spec/33)
+3. [34/WAKU2-PEER-EXCHANGE](/spec/34)
+
+Status Clients MAY use any combination of the above peer discovery methods, 
+which is suited best for their implementation.
+
+# Security/Privacy Considerations
+
+This specification inherits the security and privacy considerations from the following specifications -
+
+1. [10/WAKU2](/spec/10)
+2. [11/WAKU2-RELAY](/spec/11)
+3. [12/WAKU2-FILTER](/spec/12)
+4. [13/WAKU2-STORE](/spec/13)
+5. [14/WAKU2-MESSAGE](/spec/14)
+6. [23/WAKU2-TOPICS](/spec/23)
+7. [19/WAKU2-LIGHTPUSH](/spec/19)
+8. [55/STATUS-1TO1-CHAT](/spec/55)
+9. [56/STATUS-COMMUNITIES](/spec/56)
+10. [62/STATUS-PAYLOAD](/spec/62)
+11. [EIP-1459: DNS-Based Discovery](https://eips.ethereum.org/EIPS/eip-1459)
+12. [33/WAKU2-DISCV5](/spec/33)
+13. [34/WAKU2-PEER-EXCHANGE](/spec/34)
+
+# Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+# References
+
+## normative
+
+- [10/WAKU2](/spec/10)
+- [11/WAKU2-RELAY](/spec/11)
+- [12/WAKU2-FILTER](/spec/12)
+- [13/WAKU2-STORE](/spec/13)
+- [14/WAKU2-MESSAGE](/spec/14)
+- [23/WAKU2-TOPICS](/spec/23)
+- [19/WAKU2-LIGHTPUSH](/spec/19)
+
+## informative
+- [55/STATUS-1TO1-CHAT](/spec/55)
+- [56/STATUS-COMMUNITIES](/spec/56)
+- [62/STATUS-PAYLOAD](/spec/62)
+- [33/WAKU2-DISCV5](/spec/33)
+- [34/WAKU2-PEER-EXCHANGE](/spec/34)

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -55,7 +55,7 @@ as described in [64/WAKU2-NETWORK](/spec/64).
 ### Light Client:
 
 A Status client that operates within resource constrained environments is a node configured as light client.
-Light clients do not run a full `RELAY`.
+Light clients do not run `RELAY`.
 Instead, using a Waku service protocol, nodes can request services from other `RELAY` nodes.
 
 # Protocol Usage

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -36,7 +36,7 @@ it is imperative to describe how each are used.
 | Name  | Description |
 | --------------- | --------- |
 | `RELAY`| This refers to the Waku Relay protocol, described in [11/WAKU2-RELAY](/spec/11) |
-|`FILTER` | This refers to the Waku Filter protocol, described in [12/WAKU2-FILTER](/spec/12) |
+| `FILTER` | This refers to the Waku Filter protocol, described in [12/WAKU2-FILTER](/spec/12) |
 | `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
 | `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -3,7 +3,7 @@ slug: 67
 title: 67/STATUS-WAKU2-USAGE
 name: Status Waku2 Usage
 status: raw
-category: Best Common Practice
+category: Best Current Practice
 description: Get familiar with all the Waku protocols used by the Status application.
 editor: Aaryamann Challani <aaryamann@status.im>
 contributors: 

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -4,7 +4,7 @@ title: 67/STATUS-WAKU2-USAGE
 name: Status Waku2 Usage
 status: raw
 category: Best Current Practice
-description: Get familiar with all the Waku protocols used by the Status application.
+description: Defines how the Status application uses the Waku protocols.
 editor: Aaryamann Challani <aaryamann@status.im>
 contributors: 
 - Jimmy Debe <jimmy@status.im>
@@ -41,31 +41,32 @@ it is imperative to describe how each are used.
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
 | `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
 | Discovery | This refers to a peer discovery method used by a Waku node. |
-| `Pubsub Topic` / `Content Topic` | This refers to the routing and filtering of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
+| `Pubsub Topic` / `Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
 
 ### Waku Node:
 
 Software that is configured with a set of Waku protocols.
-A Status client comprises of a Waku node that can be a relay node or
-a non-relay node.
+A Status client comprises of a Waku node that is a `RELAY` node or a non-relay node.
 
-The Waku network is a group of Waku nodes used to create an open access messaging network, 
-as described in [64/WAKU2-NETWORK](/spec/64).
 
 ### Light Client:
 
 A Status client that operates within resource constrained environments is a node configured as light client.
-Light clients do not run `RELAY`.
-Instead, using a Waku service protocol, nodes can request services from other `RELAY` nodes.
+Light clients do not run a `RELAY`.
+Instead, Status light clients,
+can request services from other `RELAY` node that provide `LIGHTPUSH` service.
 
 # Protocol Usage
 
-The following is a list of Waku Protocols used by the Status application.
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, 
+“NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+The following is a list of Waku Protocols used by a Status application.
 
 ## 1. `RELAY`
 
 The `RELAY` MUST NOT be used by Status light clients.
-The `RELAY` is used to broadcast messages from a Status client nodes to peers in the [64/WAKU2-NETWORK](/spec/64).
+The `RELAY` is used to broadcast messages between Status clients.
 All Status messages are transformed into [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
 
 All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
@@ -108,7 +109,7 @@ Status clients SHOULD request historical messages from this service node.
 
 The messages that have the `WakuMessage.Ephemeral` flag set to true will not be stored.
 
-The Status client SHOULD provide a method to prune the database of older records to save storage.
+The Status client MAY provide a method to prune the database of older records to save storage.
 
 ## 3. `FILTER`
 
@@ -118,10 +119,13 @@ This protocol SHOULD be used to filter messages based on a given criteria, such 
 This allows a reduction in bandwidth consumption by the Status client.
 
 ### Content filtering protocol identifers:
+The `filter-subcribe` SHOULD be implemented on `RELAY` nodes to provide `FILTER` services.
 
 `filter-subscribe`:
 
     /vac/waku/filter-subscribe/2.0.0-beta1
+
+The `filter-push` SHOULD be implemented on light clients to receive messages.
 
 `filter-push`:
 
@@ -136,7 +140,7 @@ such as `Content Topic` derived from -
 ## 4. `LIGHTPUSH`
 
 The `LIGHTPUSH` protocol MUST be enabled on Status light clients.
-A Status `RELAY` node SHOULD implement `LIGHTPUSH` to support light clients. 
+A Status `RELAY` node MAY implement `LIGHTPUSH` to support light clients. 
 Peers will be able to publish messages,
 without running a full-fledged [11/WAKU2-RELAY](/spec/11) protocol.
 
@@ -155,7 +159,7 @@ such as -
 2. [33/WAKU2-DISCV5](/spec/33): 
 A node discovery protocol to create decentralized network of interconnected Waku nodes. 
 3. [34/WAKU2-PEER-EXCHANGE](/spec/34):
-A peer discovery protocol for resource restricting devices.
+A peer discovery protocol for resource restricted devices.
 
 Status clients MAY use any combination of the above peer discovery methods, 
 which is suited best for their implementation.

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -121,8 +121,16 @@ The Status client SHOULD provide a method to prune the database of older records
 > Note: This protocol SHOULD be enabled on Light clients.
 
 This protocol SHOULD be used to filter messages based on a given criteria, such as the `Content Topic` of a `MESSAGE`.
-
 This allows a reduction in bandwidth consumption by the Status client.
+
+### Content filtering protocol identifers:
+
+filter-subscribe:
+
+    /vac/waku/filter-subscribe/2.0.0-beta1
+filter-push:
+
+    /vac/waku/filter-push/2.0.0-beta1
 
 Status clients SHOULD apply a filter for all the `Content Topic` they are interested in, 
 such as `Content Topic` derived from -
@@ -137,22 +145,24 @@ such as `Content Topic` derived from -
 This protocol allows Status light clients to publish messages to the Waku Network,
 without running a full-fledged Waku Relay protocol.
 
-When a Status Client is publishing a message, 
+When a Status client is publishing a message, 
 it MUST check if Light mode is enabled,
-and if so, it MUST publish the message via `LIGHTPUSH`.
+and if so, it MUST publish the message via this protocol.
 
 ## 5. `DISCOVERY`
 
 > Note: This protocol MUST be supported by Light clients and Full clients
 
-Status Clients SHOULD make use of the following peer discovery methods that are provided by Waku,
+Status clients SHOULD make use of the following peer discovery methods that are provided by Waku,
 such as -
 
 1. [EIP-1459: DNS-Based Discovery](https://eips.ethereum.org/EIPS/eip-1459)
-2. [33/WAKU2-DISCV5](/spec/33)
-3. [34/WAKU2-PEER-EXCHANGE](/spec/34)
+2. [33/WAKU2-DISCV5](/spec/33): 
+A node discovery protocol to create decentralized network of interconnected Waku nodes. 
+3. [34/WAKU2-PEER-EXCHANGE](/spec/34):
+A peer discovery protocol for resoruce restricting devices.
 
-Status Clients MAY use any combination of the above peer discovery methods, 
+Status clients MAY use any combination of the above peer discovery methods, 
 which is suited best for their implementation.
 
 # Security/Privacy Considerations

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -3,7 +3,7 @@ slug: 67
 title: 67/STATUS-WAKU2-USAGE
 name: Status Waku2 Usage
 status: raw
-category: Standards Track
+category: Best Common Practice
 description: Get familiar with all the Waku protocols used by the Status application.
 editor: Aaryamann Challani <aaryamann@status.im>
 contributors: 
@@ -40,13 +40,13 @@ it is imperative to describe how each are used.
 | `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
 | `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
-| `Pubsub Topic` / `Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
-
+| DISCOVERY | This refers to a peer discovery method used by a Waku node |
+| `Pubsub Topic` / `Content Topic` | This refers to the routing and filtering of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
 
 ### Waku Node:
 
-A server running Waku software configured with a set of protocols.
-A Status client is a Waku node as that can be a full relay node or
+Software that is configured with a set of Waku protocols.
+A Status client comprises of a Waku node that can be a relay node or
 a non-relay node.
 
 The Waku network is a group of Waku nodes used to create an open access messaging network, 
@@ -64,9 +64,8 @@ The following is a list of Waku Protocols used by the Status application.
 
 ## 1. `RELAY`
 
-> Note: This protocol MUST not be used by Status light clients.
-
-This protocol is used to broadcast messages from a Status client.
+The `RELAY` MUST not be used by Status light clients.
+The `RELAY` is used to broadcast messages from a Status client nodes to peers in the [64/WAKU2-NETWORK](/spec/64).
 All Status messages are transformed into [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
 
 All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
@@ -92,11 +91,6 @@ type StatusMessage struct {
 If both are received, the implementation MUST throw an error.
 2. `WakuMessage.Payload` MUST be set to `StatusMessage.Payload` 
 3. `WakuMessage.Key` MUST be set to `StatusMessage.SymKey`
-<!-- 
-Curious about the key that is being set within the message here -
-https://github.com/status-im/status-go/blob/dc6fe5613a0b59249b11d14477f581ed636a8153/wakuv2/api.go#L217-L219
-are we sharing the symmetric key for each message?
--->
 4. `WakuMessage.Version` MUST be set to `1`
 5. `WakuMessage.Ephemeral` MUST be set to `StatusMessage.Ephemeral`
 6. `WakuMessage.ContentTopic` MUST be set to `StatusMessage.ContentTopic`
@@ -125,10 +119,11 @@ This allows a reduction in bandwidth consumption by the Status client.
 
 ### Content filtering protocol identifers:
 
-filter-subscribe:
+`filter-subscribe`:
 
     /vac/waku/filter-subscribe/2.0.0-beta1
-filter-push:
+
+`filter-push`:
 
     /vac/waku/filter-push/2.0.0-beta1
 
@@ -140,18 +135,17 @@ such as `Content Topic` derived from -
 
 ## 4. `LIGHTPUSH`
 
-> Note: This protocol MUST be enabled solely on Light clients.
-
-This protocol allows Status light clients to publish messages to the Waku Network,
-without running a full-fledged Waku Relay protocol.
+The `LIGHTPUSH` protocol MUST be enabled solely on Light clients.
+Status light clients are able to publish messages to the [64/WAKU2-NETWORK](/spec/64),
+without running a full-fledged [11/WAKU2-RELAY](/spec/11) protocol.
 
 When a Status client is publishing a message, 
 it MUST check if Light mode is enabled,
 and if so, it MUST publish the message via this protocol.
 
-## 5. `DISCOVERY`
+## 5. Discovery
 
-> Note: This protocol MUST be supported by Light clients and Full clients
+A discovery method MUST be supported by Light clients and Full clients
 
 Status clients SHOULD make use of the following peer discovery methods that are provided by Waku,
 such as -

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -5,9 +5,9 @@ name: Status Waku2 Usage
 status: raw
 category: Standards Track
 description: Get familiar with all the Waku protocols used by the Status application.
-editor: Jimmy Debe <jimmy@status.im>
+editor: Aaryamann Challani <aaryamann@status.im>
 contributors: 
-- Aaryamann Challani <aaryamann@status.im>
+- Jimmy Debe <jimmy@status.im>
 
 ---
 
@@ -31,50 +31,61 @@ censorship resistance and spam protected communcation.
 Since Status uses a large set of Waku protocols, 
 it is imperative to describe how each are used. 
 
-# Definitions
+# Terminology
 
-| Terminology  | Description |
+| Name  | Description |
 | --------------- | --------- |
 | `RELAY`| This refers to the Waku Relay protocol, described in [11/WAKU2-RELAY](/spec/11) |
 |`FILTER` | This refers to the Waku Filter protocol, described in [12/WAKU2-FILTER](/spec/12) |
 | `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
-| `Pubsub Topic` / `Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
 | `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
+| `Pubsub Topic` / `Content Topic` | This refers to the routing of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
 
-# Semantics
-Waku Node : A server running Waku software configured with a set of protocols
 
-Light Client: Status clients that operate within resource constrained environments, and uses only a subset of Waku Protocols.
+### Waku Node:
 
+A server running Waku software configured with a set of protocols.
+A Status client is a Waku node as that can be a full relay node or
+a non-relay node.
+
+The Waku network is a group of Waku nodes used to create an open access messaging network, 
+as described in [64/WAKU2-NETWORK](/spec/64).
+
+### Light Client:
+
+A Status client that operates within resource constrained environments is a node configured as light client.
+Light clients do not run a full `RELAY`.
+Instead, using a Waku service protocol, nodes can request services from other `RELAY` nodes.
 
 # Protocol Usage
 
 The following is a list of Waku Protocols used by the Status application.
 
-
 ## 1. `RELAY`
 
 > Note: This protocol MUST not be used by Status light clients.
 
-Waku Relay is used to broadcast messages from a Status Client.
-All Status messages are transformed into Waku Messages, [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
-All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
+This protocol is used to broadcast messages from a Status client.
+All Status messages are transformed into [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
 
+All Status message types are described in [62/STATUS-PAYLOAD](/spec/62).
 Status Clients MUST transform the following object into a `MESSAGE` as described below -
 
 ```go
-StatusSendMessage {
-	SymKey[]     []byte // [optional] The symmetric key used to encrypt the message
-	PublicKey    []byte // [optional] The public key to use for asymmetric encryption
-	Sig          string // [optional] The private key used to sign the message
-	PubsubTopic  string // The Pubsub topic to publish the message to     
-	ContentTopic string // The Content topic to publish the message to
-	Payload      []byte // A serialized representation of a Status message to be sent
-	Padding      []byte // Padding that must be applied to the Payload
-	TargetPeer   string // [optional] The target recipient of the message
-	Ephemeral    bool   // If the message is not to be stored, this is set to `true` 
+
+type StatusMessage struct {
+    SymKey[]     []byte // [optional] The symmetric key used to encrypt the message
+    PublicKey    []byte // [optional] The public key to use for asymmetric encryption
+    Sig          string // [optional] The private key used to sign the message
+    PubsubTopic  string // The Pubsub topic to publish the message to     
+    ContentTopic string // The Content topic to publish the message to
+    Payload      []byte // A serialized representation of a Status message to be sent
+    Padding      []byte // Padding that must be applied to the Payload
+    TargetPeer   string // [optional] The target recipient of the message
+    Ephemeral    bool   // If the message is not to be stored, this is set to `true` 
 }
+
 ```
 
 1. A user MUST only provide either a Symmetric key OR an Asymmetric keypair to encrypt the message.
@@ -96,21 +107,25 @@ are we sharing the symmetric key for each message?
 > Note: This protocol MUST remain optional according to the user's preferences,
 it MAY be enabled on Light clients as well.
 
-Messages received via Waku Relay, are stored in a database as described in [13/WAKU2-STORE](/spec/13).
-The messages that have the `ephemeral` flag set to true will not be stored.
+Messages received via [11/WAKU2-RELAY](/spec/11), are stored in a database.
+When Waku node running this protocol is service node, 
+it MUST provide the complete list of network messages.
+Status clients COULD request historical messages from this service node.
 
-The Status Client SHOULD provide a method to prune the database of older records to save storage.
+The messages that have the `WakuMessage.Ephemeral` flag set to true will not be stored.
+
+The Status client SHOULD provide a method to prune the database of older records to save storage.
 
 ## 3. `FILTER`
 
 > Note: This protocol SHOULD be enabled on Light clients.
 
-This protocol SHOULD be used to filter messages based on a given criteria, such as the Content Topic of a Waku Message.
+This protocol SHOULD be used to filter messages based on a given criteria, such as the `Content Topic` of a `MESSAGE`.
 
-This allows a reduction in bandwidth consumption by the Status Client.
+This allows a reduction in bandwidth consumption by the Status client.
 
-Status Clients SHOULD apply a filter for all the Content Topics they are interested in, 
-such as Content Topics derived from -
+Status clients SHOULD apply a filter for all the `Content Topic` they are interested in, 
+such as `Content Topic` derived from -
 1. 1:1 chats with other users, described in [55/STATUS-1TO1-CHAT](/spec/55)
 2. Group chats
 3. Community Channels, described in [56/STATUS-COMMUNITIES](/spec/56)
@@ -119,7 +134,7 @@ such as Content Topics derived from -
 
 > Note: This protocol MUST be enabled solely on Light clients.
 
-This protocol allows Status Light Clients to publish messages to the Waku Network,
+This protocol allows Status light clients to publish messages to the Waku Network,
 without running a full-fledged Waku Relay protocol.
 
 When a Status Client is publishing a message, 
@@ -164,19 +179,18 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 
 # References
 
-## normative
 
-- [10/WAKU2](/spec/10)
-- [11/WAKU2-RELAY](/spec/11)
-- [12/WAKU2-FILTER](/spec/12)
-- [13/WAKU2-STORE](/spec/13)
-- [14/WAKU2-MESSAGE](/spec/14)
-- [23/WAKU2-TOPICS](/spec/23)
-- [19/WAKU2-LIGHTPUSH](/spec/19)
-
-## informative
-- [55/STATUS-1TO1-CHAT](/spec/55)
-- [56/STATUS-COMMUNITIES](/spec/56)
-- [62/STATUS-PAYLOAD](/spec/62)
-- [33/WAKU2-DISCV5](/spec/33)
-- [34/WAKU2-PEER-EXCHANGE](/spec/34)
+1. [55/STATUS-1TO1-CHAT](/spec/55)
+2. [56/STATUS-COMMUNITIES](/spec/56)
+3. [10/WAKU2](/spec/10)
+4. [11/WAKU2-RELAY](/spec/11)
+5. [12/WAKU2-FILTER](/spec/12)
+6. [13/WAKU2-STORE](/spec/13)
+7. [14/WAKU2-MESSAGE](/spec/14)
+8. [23/WAKU2-TOPICS](/spec/23)
+9. [19/WAKU2-LIGHTPUSH](/spec/19)
+10. [64/WAKU2-NETWORK](/spec/64)
+11. [62/STATUS-PAYLOAD](/spec/62)
+12. [EIP-1459: DNS-Based Discovery](https://eips.ethereum.org/EIPS/eip-1459)
+13. [33/WAKU2-DISCV5](/spec/33)
+14. [34/WAKU2-PEER-EXCHANGE](/spec/34)

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -25,7 +25,7 @@ Waku, which is described in [10/WAKU2](/spec/10).
 The Status application aspires to achieve censorship resistance and incorporates specific privacy features, 
 leveraging the comprehensive set of protocols offered by Waku to enhance these attributes. 
 Waku protocols provide secure communication capabilities over decentralized networks. 
-Once integrated, an application will benifit from privacy preserving, 
+Once integrated, an application will benefit from privacy-preserving, 
 censorship resistance and spam protected communcation. 
 
 Since Status uses a large set of Waku protocols, 
@@ -64,7 +64,7 @@ The following is a list of Waku Protocols used by the Status application.
 
 ## 1. `RELAY`
 
-The `RELAY` MUST not be used by Status light clients.
+The `RELAY` MUST NOT be used by Status light clients.
 The `RELAY` is used to broadcast messages from a Status client nodes to peers in the [64/WAKU2-NETWORK](/spec/64).
 All Status messages are transformed into [14/WAKU2-MESSAGE](/spec/14), which are sent over the wire.
 
@@ -98,13 +98,13 @@ If both are received, the implementation MUST throw an error.
 
 ## 2. `STORE`
 
-> Note: This protocol MUST remain optional according to the user's preferences,
+This protocol MUST remain optional according to the user's preferences,
 it MAY be enabled on Light clients as well.
 
 Messages received via [11/WAKU2-RELAY](/spec/11), are stored in a database.
 When Waku node running this protocol is service node, 
 it MUST provide the complete list of network messages.
-Status clients COULD request historical messages from this service node.
+Status clients SHOULD request historical messages from this service node.
 
 The messages that have the `WakuMessage.Ephemeral` flag set to true will not be stored.
 
@@ -112,7 +112,7 @@ The Status client SHOULD provide a method to prune the database of older records
 
 ## 3. `FILTER`
 
-> Note: This protocol SHOULD be enabled on Light clients.
+This protocol SHOULD be enabled on Light clients.
 
 This protocol SHOULD be used to filter messages based on a given criteria, such as the `Content Topic` of a `MESSAGE`.
 This allows a reduction in bandwidth consumption by the Status client.
@@ -135,8 +135,9 @@ such as `Content Topic` derived from -
 
 ## 4. `LIGHTPUSH`
 
-The `LIGHTPUSH` protocol MUST be enabled solely on Light clients.
-Status light clients are able to publish messages to the [64/WAKU2-NETWORK](/spec/64),
+The `LIGHTPUSH` protocol MUST be enabled on Status light clients.
+A Status `RELAY` node SHOULD implement `LIGHTPUSH` to support light clients. 
+Peers will be able to publish messages,
 without running a full-fledged [11/WAKU2-RELAY](/spec/11) protocol.
 
 When a Status client is publishing a message, 
@@ -154,7 +155,7 @@ such as -
 2. [33/WAKU2-DISCV5](/spec/33): 
 A node discovery protocol to create decentralized network of interconnected Waku nodes. 
 3. [34/WAKU2-PEER-EXCHANGE](/spec/34):
-A peer discovery protocol for resoruce restricting devices.
+A peer discovery protocol for resource restricting devices.
 
 Status clients MAY use any combination of the above peer discovery methods, 
 which is suited best for their implementation.

--- a/content/docs/rfcs/67/README.md
+++ b/content/docs/rfcs/67/README.md
@@ -40,7 +40,7 @@ it is imperative to describe how each are used.
 | `STORE` | This refers to the Waku Store protocol, described in [13/WAKU2-STORE](/spec/13) |
 | `MESSAGE` | This refers to the Waku Message format, described in [14/WAKU2-MESSAGE](/spec/14) |
 | `LIGHTPUSH` | This refers to the Waku Lightpush protocol, described in [19/WAKU2-LIGHTPUSH](/spec/19) |
-| DISCOVERY | This refers to a peer discovery method used by a Waku node |
+| Discovery | This refers to a peer discovery method used by a Waku node. |
 | `Pubsub Topic` / `Content Topic` | This refers to the routing and filtering of messages within the Waku network, described in [23/WAKU2-TOPICS](/spec/23/) |
 
 ### Waku Node:

--- a/content/menu/index.md
+++ b/content/menu/index.md
@@ -27,6 +27,7 @@ bookMenuLevels: 1
   - [63/STATUS-Keycard-Usage]({{< relref "/docs/rfcs/63/README.md" >}})
   - [64/WAKU2-NETWORK]({{< relref "/docs/rfcs/64/README.md" >}})
   - [66/WAKU2-METADATA]({{< relref "/docs/rfcs/66/README.md" >}})
+  - [67/STATUS-WAKU2-USAGE]({{< relref "/docs/rfcs/67/README.md" >}})
   - [70/ETH-SECPM]({{< relref "/docs/rfcs/70/README.md" >}})
 - Draft
   - [1/COSS]({{< relref "/docs/rfcs/1/README.md" >}})


### PR DESCRIPTION
This RFC includes how status currently uses Wakuv2. It can be extended in the future for additional protocols, such as RLN.
ref: https://github.com/vacp2p/rfc/issues/608