### PR TITLE
Waku2: Clarifying Content Topic

### DIFF
--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -119,8 +119,8 @@ The following usage requirements apply:
 
 - The `topicid` field MUST contain the pubsub topic.
 
-> Note: `topicid` refers to pubsub topic and
-`topicId` refers to content-topic are detailed in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/) as 
+> Note: The `topicid` refering to pubsub topic and
+`topicId` refering to content-topic are detailed in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/).
 
 ## Signature Policy
 

--- a/content/docs/rfcs/11/README.md
+++ b/content/docs/rfcs/11/README.md
@@ -103,7 +103,7 @@ See [`14/WAKU2-MESSAGE`](/spec/14) for more details.
 
 - The `seqno` field MUST NOT be used, following the [`StrictNoSign` signature policy](#signature-policy).
 
-- The `topicIDs` field MUST contain the topics that a message is being published on.
+- The `topicIDs` field MUST contain the content-topics that a message is being published on.
 
 - The `signature` field MUST NOT be used, following the [`StrictNoSign` signature policy](#signature-policy).
 
@@ -117,7 +117,10 @@ The following usage requirements apply:
 
 - The `subscribe` field MUST contain a boolean, where `true` indicates subscribe and `false` indicates unsubscribe to a topic.
 
-- The `topicid` field MUST contain the topic.
+- The `topicid` field MUST contain the pubsub topic.
+
+> Note: `topicid` refers to pubsub topic and
+`topicId` refers to content-topic are detailed in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/) as 
 
 ## Signature Policy
 

--- a/content/docs/rfcs/12/README.md
+++ b/content/docs/rfcs/12/README.md
@@ -27,8 +27,10 @@ previous versions: [00](/spec/12/previous-versions/00/)
 
 Content filtering is a way to do [message-based
 filtering](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern#Message_filtering).
-Currently the only content filter being applied is on `contentTopic`. This
-corresponds to topics in Waku v1.
+Currently the only content filter being applied is on `contentTopic`.
+This corresponds to topics in Waku v1.
+The `contentTopic` is described in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/).
+
 
 ## Rationale
 

--- a/content/docs/rfcs/14/README.md
+++ b/content/docs/rfcs/14/README.md
@@ -49,7 +49,8 @@ The data payload is also treated as a Waku message attribute for convenience.
 
 * The `payload` attribute MUST contain the message data payload to be sent.
 
-* The `content_topic` attribute MUST specify a string identifier that can be used for content-based filtering.
+* The `content_topic` attribute MUST specify a string identifier that can be used for content-based filtering,
+as described in [23/WAKU2-TOPICS](https://rfc.vac.dev/spec/23/).
 
 * The `meta` attribute, if present, contains an arbitrary application-specific variable-length byte array with a maximum length limit of 64 bytes.
 This attribute can be utilized to convey supplementary details to various Waku protocols, thereby enabling customized processing based on its contents.


### PR DESCRIPTION
Adding content-topic spec to avoid confusion of pubsub topic and content-topic.